### PR TITLE
v0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Or install it yourself as:
 
 ### Verifying the kind of some object
 
-By default, basic type verification is strict. So, when you perform `Kind.of.Hash(value)`, if the given value was a Hash it will be returned, but if it wasn't one, an error will be raised.
+By default, basic verifications are strict. So, when you perform `Kind.of.Hash(value)`, if the given value was a Hash, the value itself will be returned, but if it isn't the right type, an error will be raised.
 
 ```ruby
 Kind.of.Hash('')
@@ -69,6 +69,20 @@ Kind.of.Boolean(nil)
 
 Kind.of.Boolean(true)  # true
 Kind.of.Boolean(false) # false
+```
+
+When the verified value is nil, it is possible to define a default value with the same type to be returned.
+
+```ruby
+value = nil
+
+Kind.of.Hash(value, or: {})
+# {}
+
+# ---
+
+Kind.of.Boolean(nil, or: true)
+# true
 ```
 
 As an alternative syntax, you can use the `Kind::Of` instead of the method. e.g: `Kind::Of::Hash('')`

--- a/lib/kind/version.rb
+++ b/lib/kind/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Kind
-  VERSION = '0.4.0'
+  VERSION = '0.5.0'
 end

--- a/test/kind/of_test.rb
+++ b/test/kind/of_test.rb
@@ -3,122 +3,246 @@ require 'test_helper'
 class Kind::OfMethodsTest < Minitest::Test
   # --- Classes
 
-  def test_if_a_value_is_a_kind_of_string
+  def test_if_the_object_is_a_kind_of_string
     err = assert_raises(Kind::Error) { Kind.of.String(:a) }
     assert_equal(':a expected to be a kind of String', err.message)
 
-    value = 'a'
+    # --
 
-    assert_same(value, Kind.of.String(value))
+    object = 'a'
+
+    assert_same(object, Kind.of.String(object))
+
+    assert_equal('default', Kind.of.String(nil, or: 'default'))
+
+    # --
+
+    error = assert_raises(Kind::Error) { Kind.of.String(nil, or: :default) }
+    assert_equal(':default expected to be a kind of String', error.message)
   end
 
-  def test_if_a_value_is_a_kind_of_symbol
+  def test_if_the_object_is_a_kind_of_symbol
     err = assert_raises(Kind::Error) { Kind.of.Symbol('a') }
     assert_equal('"a" expected to be a kind of Symbol', err.message)
 
-    value = :a
+    # --
 
-    assert_same(value, Kind.of.Symbol(value))
+    object = :a
+
+    assert_same(object, Kind.of.Symbol(object))
+
+    assert_equal(:default, Kind.of.Symbol(nil, or: :default))
+
+    # --
+
+    error = assert_raises(Kind::Error) { Kind.of.Symbol(nil, or: 'default') }
+    assert_equal('"default" expected to be a kind of Symbol', error.message)
   end
 
-  def test_if_a_value_is_a_kind_of_numeric
+  def test_if_the_object_is_a_kind_of_numeric
     err = assert_raises(Kind::Error) { Kind.of.Numeric('1') }
     assert_equal('"1" expected to be a kind of Numeric', err.message)
 
-    value1 = 1
-    assert_same(value1, Kind.of.Numeric(value1))
+    # --
 
-    value2 = 1.0
-    assert_same(value2, Kind.of.Numeric(value2))
+    object1 = 1
+    object2 = 1.0
+
+    assert_same(object1, Kind.of.Numeric(object1))
+    assert_same(object2, Kind.of.Numeric(object2))
+
+    assert_equal(1, Kind.of.Numeric(nil, or: 1))
+    assert_equal(1.0, Kind.of.Numeric(nil, or: 1.0))
+
+    # --
+
+    error = assert_raises(Kind::Error) { Kind.of.Numeric(nil, or: 'default') }
+    assert_equal('"default" expected to be a kind of Numeric', error.message)
   end
 
-  def test_if_a_value_is_a_kind_of_integer
+  def test_if_the_object_is_a_kind_of_integer
     err = assert_raises(Kind::Error) { Kind.of.Integer(1.0) }
     assert_equal('1.0 expected to be a kind of Integer', err.message)
 
-    value = 1
-    assert_same(value, Kind.of.Integer(value))
+    # --
+
+    object = 1
+
+    assert_same(object, Kind.of.Integer(object))
+
+    assert_equal(1, Kind.of.Integer(nil, or: 1))
+
+    # --
+
+    error = assert_raises(Kind::Error) { Kind.of.Integer(nil, or: 'default') }
+    assert_equal('"default" expected to be a kind of Integer', error.message)
   end
 
-  def test_if_a_value_is_a_kind_of_float
+  def test_if_the_object_is_a_kind_of_float
     err = assert_raises(Kind::Error) { Kind.of.Float(1) }
     assert_equal('1 expected to be a kind of Float', err.message)
 
-    value = 1.0
-    assert_same(value, Kind.of.Float(value))
+    # --
+
+    object = 1.0
+
+    assert_same(object, Kind.of.Float(object))
+
+    assert_equal(1.0, Kind.of.Float(nil, or: 1.0))
+
+    # --
+
+    error = assert_raises(Kind::Error) { Kind.of.Float(nil, or: 'default') }
+    assert_equal('"default" expected to be a kind of Float', error.message)
   end
 
-  def test_if_a_value_is_a_kind_of_regexp
+  def test_if_the_object_is_a_kind_of_regexp
     err = assert_raises(Kind::Error) { Kind.of.Regexp(1) }
     assert_equal('1 expected to be a kind of Regexp', err.message)
 
-    value = /1.0/
-    assert_same(value, Kind.of.Regexp(value))
+    # --
+
+    object = /1.0/
+
+    assert_same(object, Kind.of.Regexp(object))
+
+    assert_equal(/2.0/, Kind.of.Regexp(nil, or: /2.0/))
+
+    # --
+
+    error = assert_raises(Kind::Error) { Kind.of.Regexp(nil, or: 'default') }
+    assert_equal('"default" expected to be a kind of Regexp', error.message)
   end
 
-  def test_if_a_value_is_a_kind_of_time
+  def test_if_the_object_is_a_kind_of_time
     err = assert_raises(Kind::Error) { Kind.of.Time(1) }
     assert_equal('1 expected to be a kind of Time', err.message)
 
-    value = Time.now
-    assert_same(value, Kind.of.Time(value))
+    # --
+
+    object = Time.now
+
+    assert_same(object, Kind.of.Time(object))
+
+    assert_equal(object, Kind.of.Time(nil, or: object))
+
+    # --
+
+    error = assert_raises(Kind::Error) { Kind.of.Time(nil, or: 'default') }
+    assert_equal('"default" expected to be a kind of Time', error.message)
   end
 
-  def test_if_a_value_is_a_kind_of_array
+  def test_if_the_object_is_a_kind_of_array
     err = assert_raises(Kind::Error) { Kind.of.Array(1) }
     assert_equal('1 expected to be a kind of Array', err.message)
 
-    value = []
-    assert_same(value, Kind.of.Array(value))
+    # --
+
+    object = []
+
+    assert_same(object, Kind.of.Array(object))
+
+    assert_equal([], Kind.of.Array(nil, or: []))
+
+    # --
+
+    error = assert_raises(Kind::Error) { Kind.of.Array(nil, or: 'default') }
+    assert_equal('"default" expected to be a kind of Array', error.message)
   end
 
-  def test_if_a_value_is_a_kind_of_range
+  def test_if_the_object_is_a_kind_of_range
     err = assert_raises(Kind::Error) { Kind.of.Range(1) }
     assert_equal('1 expected to be a kind of Range', err.message)
 
-    value = 1..2
-    assert_same(value, Kind.of.Range(value))
+    # --
+
+    object = 1..2
+
+    assert_same(object, Kind.of.Range(object))
+
+    assert_equal(2..3, Kind.of.Range(nil, or: 2..3))
+
+    # --
+
+    error = assert_raises(Kind::Error) { Kind.of.Range(nil, or: 'default') }
+    assert_equal('"default" expected to be a kind of Range', error.message)
   end
 
-  def test_if_a_value_is_a_kind_of_hash
+  def test_if_the_object_is_a_kind_of_hash
     err = assert_raises(Kind::Error) { Kind.of.Hash([]) }
     assert_equal('[] expected to be a kind of Hash', err.message)
 
-    value = { a: 1 }
+    # --
 
-    assert_same(value, Kind.of.Hash(value))
+    object = { a: 1 }
+
+    assert_same(object, Kind.of.Hash(object))
+
+    assert_equal({}, Kind.of.Hash(nil, or: {}))
+
+    # --
+
+    error = assert_raises(Kind::Error) { Kind.of.Hash(nil, or: 'default') }
+    assert_equal('"default" expected to be a kind of Hash', error.message)
   end
 
-  def test_if_a_value_is_a_kind_of_struct
+  def test_if_the_object_is_a_kind_of_struct
     err = assert_raises(Kind::Error) { Kind.of.Struct([]) }
     assert_equal('[] expected to be a kind of Struct', err.message)
 
+    # --
+
     person = Struct.new(:name)
 
-    value = person.new('John Doe')
+    object = person.new('John Doe')
 
-    assert_same(value, Kind.of.Struct(value))
+    assert_same(object, Kind.of.Struct(object))
+
+    assert_equal(object, Kind.of.Struct(nil, or: object))
+
+    # --
+
+    error = assert_raises(Kind::Error) { Kind.of.Struct(nil, or: 'default') }
+    assert_equal('"default" expected to be a kind of Struct', error.message)
   end
 
-  def test_if_a_value_is_a_kind_of_enumerator
+  def test_if_the_object_is_a_kind_of_enumerator
     err = assert_raises(Kind::Error) { Kind.of.Enumerator([]) }
     assert_equal('[] expected to be a kind of Enumerator', err.message)
 
-    value = [].each
+    # --
 
-    assert_same(value, Kind.of.Enumerator(value))
+    object = [].each
+
+    assert_same(object, Kind.of.Enumerator(object))
+
+    assert_equal(object, Kind.of.Enumerator(nil, or: object))
+
+    # --
+
+    error = assert_raises(Kind::Error) { Kind.of.Enumerator(nil, or: 'default') }
+    assert_equal('"default" expected to be a kind of Enumerator', error.message)
   end
 
-  def test_if_a_value_is_a_kind_of_method
+  def test_if_the_object_is_a_kind_of_method
     err = assert_raises(Kind::Error) { Kind.of.Method([]) }
     assert_equal('[] expected to be a kind of Method', err.message)
 
-    value = [1,2].method(:first)
+    # --
 
-    assert_same(value, Kind.of.Method(value))
+    object = [1,2].method(:first)
+
+    assert_same(object, Kind.of.Method(object))
+
+    assert_equal(object, Kind.of.Method(nil, or: object))
+
+    # --
+
+    error = assert_raises(Kind::Error) { Kind.of.Method(nil, or: 'default') }
+    assert_equal('"default" expected to be a kind of Method', error.message)
   end
 
-  def test_if_a_value_is_a_kind_of_proc
+  def test_if_the_object_is_a_kind_of_proc
     err = assert_raises(Kind::Error) { Kind.of.Proc([]) }
     assert_equal('[] expected to be a kind of Proc', err.message)
 
@@ -127,28 +251,55 @@ class Kind::OfMethodsTest < Minitest::Test
 
     assert_same(sum, Kind.of.Proc(sum))
     assert_same(sub, Kind.of.Proc(sub))
+
+    assert_equal(sum, Kind.of.Proc(nil, or: sum))
+    assert_equal(sub, Kind.of.Proc(nil, or: sub))
+
+    # --
+
+    error = assert_raises(Kind::Error) { Kind.of.Proc(nil, or: 'default') }
+    assert_equal('"default" expected to be a kind of Proc', error.message)
   end
 
-  def test_if_a_value_is_a_kind_of_file
+  def test_if_the_object_is_a_kind_of_file
     err = assert_raises(Kind::Error) { Kind.of.File([]) }
     assert_equal('[] expected to be a kind of File', err.message)
 
-    value = File.new('.foo', 'w')
+    object = File.new('.foo', 'w')
 
-    assert_same(value, Kind.of.File(value))
+    assert_same(object, Kind.of.File(object))
+
+    assert_equal(object, Kind.of.File(nil, or: object))
+
+    # --
+
+    error = assert_raises(Kind::Error) { Kind.of.File(nil, or: 'default') }
+    assert_equal('"default" expected to be a kind of File', error.message)
   end
 
-  def test_if_a_value_is_a_kind_of_boolean
+  def test_if_the_object_is_a_kind_of_boolean
     err = assert_raises(Kind::Error) { Kind.of.Boolean(:a) }
     assert_equal(':a expected to be a kind of Boolean', err.message)
 
+    # --
+
     assert_same(true, Kind.of.Boolean(true))
     assert_same(false, Kind.of.Boolean(false))
+
+    assert_same(true, Kind.of.Boolean(nil, or: true))
+    assert_same(false, Kind.of.Boolean(nil, or: false))
+
+    # --
+
+    error = assert_raises(Kind::Error) { Kind.of.Boolean(nil, or: 'default') }
+    assert_equal('"default" expected to be a kind of Boolean', error.message)
   end
 
-  def test_if_a_value_is_a_kind_of_lambda
+  def test_if_the_object_is_a_kind_of_lambda
     sum = proc { |a, b| a + b }
     sub = lambda { |a, b| a - b }
+
+    # --
 
     err1 = assert_raises(Kind::Error) { Kind.of.Lambda([]) }
     assert_equal('[] expected to be a kind of Lambda', err1.message)
@@ -156,26 +307,49 @@ class Kind::OfMethodsTest < Minitest::Test
     err2 = assert_raises(Kind::Error) { Kind.of.Lambda(sum) }
     assert_match(/<Proc:.*> expected to be a kind of Lambda/, err2.message)
 
+    # --
+
     assert_same(sub, Kind.of.Lambda(sub))
+
+    assert_equal(sub, Kind.of.Lambda(nil, or: sub))
+
+    # --
+
+    error = assert_raises(Kind::Error) { Kind.of.Lambda(nil, or: 'default') }
+    assert_equal('"default" expected to be a kind of Lambda', error.message)
   end
 
   # --- Modules
 
-  def test_if_a_value_is_a_kind_of_enumerable
+  def test_if_the_object_is_a_kind_of_enumerable
     err = assert_raises(Kind::Error) { Kind.of.Enumerable(1) }
     assert_equal('1 expected to be a kind of Enumerable', err.message)
 
-    value = []
+    object = []
 
-    assert_same(value, Kind.of.Enumerable(value))
+    assert_same(object, Kind.of.Enumerable(object))
+
+    assert_equal(object, Kind.of.Enumerable(nil, or: object))
+
+    # --
+
+    error = assert_raises(Kind::Error) { Kind.of.Enumerable(nil, or: 'default') }
+    assert_equal('"default" expected to be a kind of Enumerable', error.message)
   end
 
-  def test_if_a_value_is_a_kind_of_comparable
+  def test_if_the_object_is_a_kind_of_comparable
     err = assert_raises(Kind::Error) { Kind.of.Comparable([]) }
     assert_equal('[] expected to be a kind of Comparable', err.message)
 
-    value = 'a'
+    object = 'a'
 
-    assert_same(value, Kind.of.Comparable(value))
+    assert_same(object, Kind.of.Comparable(object))
+
+    assert_equal(object, Kind.of.Comparable(nil, or: object))
+
+    # --
+
+    error = assert_raises(Kind::Error) { Kind.of.Comparable(nil, or: []) }
+    assert_equal('[] expected to be a kind of Comparable', error.message)
   end
 end


### PR DESCRIPTION
When the verified value is nil, it is possible to define a default value with the same type to be returned.

```ruby
value = nil

Kind.of.Hash(value, or: {})
# {}

# ---

Kind.of.Boolean(nil, or: true)
# true
```