### PR TITLE
[1.1.0] Making nil argument raise a Kind::Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ sum('1', 1) # Kind::Error ("\"1\" expected to be a kind of Numeric")
 By default, basic verifications are strict. So, when you perform `Kind.of.Hash(value)`, if the given value was a Hash, the value itself will be returned, but if it isn't the right type, an error will be raised.
 
 ```ruby
+Kind.of.Hash(nil)    # raise Kind::Error, "nil expected to be a kind of Hash"
+
 Kind.of.Hash('')     # raise Kind::Error, "'' expected to be a kind of Hash"
 
 Kind.of.Hash({a: 1}) # {a: 1}

--- a/lib/kind.rb
+++ b/lib/kind.rb
@@ -3,6 +3,8 @@
 require 'kind/version'
 
 module Kind
+  Undefined = Object.new
+
   class Error < TypeError
     def initialize(klass, object)
       super("#{object.inspect} expected to be a kind of #{klass}")
@@ -47,8 +49,8 @@ module Kind
       raise Kind::Error.new((name || klass.name), object)
     end
 
-    def self.Class(object = nil)
-      return Class if object.nil?
+    def self.Class(object = Undefined)
+      return Class if object == Undefined
 
       self.call(::Class, object)
     end
@@ -63,8 +65,8 @@ module Kind
       def self.instance?(value); class?(value); end
     end)
 
-    def self.Module(object = nil)
-      return Module if object.nil?
+    def self.Module(object = Undefined)
+      return Module if object == Undefined
 
       self.call(::Module, object)
     end
@@ -86,18 +88,18 @@ module Kind
     COLONS = '::'.freeze
 
     KIND_OF = <<-RUBY
-      def self.%{method_name}(object = nil, options = {})
+      def self.%{method_name}(object = Undefined, options = {})
         default = options[:or]
 
-        return Kind::Of::%{kind_name} if object.nil? && default.nil?
+        return Kind::Of::%{kind_name} if object == Undefined && default.nil?
 
         Kind::Of.(::%{kind_name}, (object || default), name: "%{kind_name}".freeze)
       end
     RUBY
 
     KIND_IS = <<-RUBY
-      def self.%{method_name}(value = nil)
-        return Kind::Is::%{kind_name} if value.nil?
+      def self.%{method_name}(value = Undefined)
+        return Kind::Is::%{kind_name} if value == Undefined
 
         Kind::Is.(::%{kind_name}, value)
       end
@@ -202,10 +204,10 @@ module Kind
   module Of
     # -- Boolean
 
-    def self.Boolean(object = nil, options = {})
+    def self.Boolean(object = Undefined, options = {})
       default = options[:or]
 
-      return Kind::Of::Boolean if object.nil? && default.nil?
+      return Kind::Of::Boolean if object == Undefined && default.nil?
 
       bool = object.nil? ? default : object
 
@@ -228,10 +230,10 @@ module Kind
 
     # -- Lambda
 
-    def self.Lambda(object = nil, options = {})
+    def self.Lambda(object = Undefined, options = {})
       default = options[:or]
 
-      return Kind::Of::Lambda if object.nil? && default.nil?
+      return Kind::Of::Lambda if object == Undefined && default.nil?
 
       func = object || default
 

--- a/lib/kind/version.rb
+++ b/lib/kind/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Kind
-  VERSION = '1.0.0'
+  VERSION = '1.1.0'
 end

--- a/test/kind/of_test.rb
+++ b/test/kind/of_test.rb
@@ -4,8 +4,8 @@ class Kind::OfMethodsTest < Minitest::Test
   # -- Classes
 
   def test_if_the_object_is_a_kind_of_string
-    err = assert_raises(Kind::Error) { Kind.of.String(:a) }
-    assert_equal(':a expected to be a kind of String', err.message)
+    assert_raises_kind_error(':a expected to be a kind of String') { Kind.of.String(:a) }
+    assert_raises_kind_error('nil expected to be a kind of String') { Kind.of.String(nil) }
 
     # ---
 
@@ -17,13 +17,12 @@ class Kind::OfMethodsTest < Minitest::Test
 
     # ---
 
-    error = assert_raises(Kind::Error) { Kind.of.String(nil, or: :default) }
-    assert_equal(':default expected to be a kind of String', error.message)
+    assert_raises_kind_error(':default expected to be a kind of String') { Kind.of.String(nil, or: :default) }
   end
 
   def test_if_the_object_is_a_kind_of_symbol
-    err = assert_raises(Kind::Error) { Kind.of.Symbol('a') }
-    assert_equal('"a" expected to be a kind of Symbol', err.message)
+    assert_raises_kind_error('"a" expected to be a kind of Symbol') { Kind.of.Symbol('a') }
+    assert_raises_kind_error('nil expected to be a kind of Symbol') { Kind.of.Symbol(nil) }
 
     # ---
 
@@ -35,13 +34,12 @@ class Kind::OfMethodsTest < Minitest::Test
 
     # ---
 
-    error = assert_raises(Kind::Error) { Kind.of.Symbol(nil, or: 'default') }
-    assert_equal('"default" expected to be a kind of Symbol', error.message)
+    assert_raises_kind_error('"default" expected to be a kind of Symbol') { Kind.of.Symbol(nil, or: 'default') }
   end
 
   def test_if_the_object_is_a_kind_of_numeric
-    err = assert_raises(Kind::Error) { Kind.of.Numeric('1') }
-    assert_equal('"1" expected to be a kind of Numeric', err.message)
+    assert_raises_kind_error('"1" expected to be a kind of Numeric') { Kind.of.Numeric('1') }
+    assert_raises_kind_error('nil expected to be a kind of Numeric') { Kind.of.Numeric(nil) }
 
     # ---
 
@@ -56,13 +54,12 @@ class Kind::OfMethodsTest < Minitest::Test
 
     # ---
 
-    error = assert_raises(Kind::Error) { Kind.of.Numeric(nil, or: 'default') }
-    assert_equal('"default" expected to be a kind of Numeric', error.message)
+    assert_raises_kind_error('"default" expected to be a kind of Numeric') { Kind.of.Numeric(nil, or: 'default') }
   end
 
   def test_if_the_object_is_a_kind_of_integer
-    err = assert_raises(Kind::Error) { Kind.of.Integer(1.0) }
-    assert_equal('1.0 expected to be a kind of Integer', err.message)
+    assert_raises_kind_error('1.0 expected to be a kind of Integer') { Kind.of.Integer(1.0) }
+    assert_raises_kind_error('nil expected to be a kind of Integer') { Kind.of.Integer(nil) }
 
     # ---
 
@@ -74,13 +71,12 @@ class Kind::OfMethodsTest < Minitest::Test
 
     # ---
 
-    error = assert_raises(Kind::Error) { Kind.of.Integer(nil, or: 'default') }
-    assert_equal('"default" expected to be a kind of Integer', error.message)
+    assert_raises_kind_error('"default" expected to be a kind of Integer') { Kind.of.Integer(nil, or: 'default') }
   end
 
   def test_if_the_object_is_a_kind_of_float
-    err = assert_raises(Kind::Error) { Kind.of.Float(1) }
-    assert_equal('1 expected to be a kind of Float', err.message)
+    assert_raises_kind_error('1 expected to be a kind of Float') { Kind.of.Float(1) }
+    assert_raises_kind_error('nil expected to be a kind of Float') { Kind.of.Float(nil) }
 
     # ---
 
@@ -92,13 +88,12 @@ class Kind::OfMethodsTest < Minitest::Test
 
     # ---
 
-    error = assert_raises(Kind::Error) { Kind.of.Float(nil, or: 'default') }
-    assert_equal('"default" expected to be a kind of Float', error.message)
+    assert_raises_kind_error('"default" expected to be a kind of Float') { Kind.of.Float(nil, or: 'default') }
   end
 
   def test_if_the_object_is_a_kind_of_regexp
-    err = assert_raises(Kind::Error) { Kind.of.Regexp(1) }
-    assert_equal('1 expected to be a kind of Regexp', err.message)
+    assert_raises_kind_error('1 expected to be a kind of Regexp') { Kind.of.Regexp(1) }
+    assert_raises_kind_error('nil expected to be a kind of Regexp') { Kind.of.Regexp(nil) }
 
     # ---
 
@@ -110,13 +105,12 @@ class Kind::OfMethodsTest < Minitest::Test
 
     # ---
 
-    error = assert_raises(Kind::Error) { Kind.of.Regexp(nil, or: 'default') }
-    assert_equal('"default" expected to be a kind of Regexp', error.message)
+    assert_raises_kind_error('"default" expected to be a kind of Regexp') { Kind.of.Regexp(nil, or: 'default') }
   end
 
   def test_if_the_object_is_a_kind_of_time
-    err = assert_raises(Kind::Error) { Kind.of.Time(1) }
-    assert_equal('1 expected to be a kind of Time', err.message)
+    assert_raises_kind_error('1 expected to be a kind of Time') { Kind.of.Time(1) }
+    assert_raises_kind_error('nil expected to be a kind of Time') { Kind.of.Time(nil) }
 
     # ---
 
@@ -128,13 +122,12 @@ class Kind::OfMethodsTest < Minitest::Test
 
     # ---
 
-    error = assert_raises(Kind::Error) { Kind.of.Time(nil, or: 'default') }
-    assert_equal('"default" expected to be a kind of Time', error.message)
+    assert_raises_kind_error('"default" expected to be a kind of Time') { Kind.of.Time(nil, or: 'default') }
   end
 
   def test_if_the_object_is_a_kind_of_array
-    err = assert_raises(Kind::Error) { Kind.of.Array(1) }
-    assert_equal('1 expected to be a kind of Array', err.message)
+    assert_raises_kind_error('1 expected to be a kind of Array') { Kind.of.Array(1) }
+    assert_raises_kind_error('nil expected to be a kind of Array') { Kind.of.Array(nil) }
 
     # ---
 
@@ -146,13 +139,12 @@ class Kind::OfMethodsTest < Minitest::Test
 
     # ---
 
-    error = assert_raises(Kind::Error) { Kind.of.Array(nil, or: 'default') }
-    assert_equal('"default" expected to be a kind of Array', error.message)
+    assert_raises_kind_error('"default" expected to be a kind of Array') { Kind.of.Array(nil, or: 'default') }
   end
 
   def test_if_the_object_is_a_kind_of_range
-    err = assert_raises(Kind::Error) { Kind.of.Range(1) }
-    assert_equal('1 expected to be a kind of Range', err.message)
+    assert_raises_kind_error('1 expected to be a kind of Range') { Kind.of.Range(1) }
+    assert_raises_kind_error('nil expected to be a kind of Range') { Kind.of.Range(nil) }
 
     # ---
 
@@ -164,13 +156,12 @@ class Kind::OfMethodsTest < Minitest::Test
 
     # ---
 
-    error = assert_raises(Kind::Error) { Kind.of.Range(nil, or: 'default') }
-    assert_equal('"default" expected to be a kind of Range', error.message)
+    assert_raises_kind_error('"default" expected to be a kind of Range') { Kind.of.Range(nil, or: 'default') }
   end
 
   def test_if_the_object_is_a_kind_of_hash
-    err = assert_raises(Kind::Error) { Kind.of.Hash([]) }
-    assert_equal('[] expected to be a kind of Hash', err.message)
+    assert_raises_kind_error('[] expected to be a kind of Hash') { Kind.of.Hash([]) }
+    assert_raises_kind_error('nil expected to be a kind of Hash') { Kind.of.Hash(nil) }
 
     # ---
 
@@ -182,13 +173,12 @@ class Kind::OfMethodsTest < Minitest::Test
 
     # ---
 
-    error = assert_raises(Kind::Error) { Kind.of.Hash(nil, or: 'default') }
-    assert_equal('"default" expected to be a kind of Hash', error.message)
+    assert_raises_kind_error('"default" expected to be a kind of Hash') { Kind.of.Hash(nil, or: 'default') }
   end
 
   def test_if_the_object_is_a_kind_of_struct
-    err = assert_raises(Kind::Error) { Kind.of.Struct([]) }
-    assert_equal('[] expected to be a kind of Struct', err.message)
+    assert_raises_kind_error('[] expected to be a kind of Struct') { Kind.of.Struct([]) }
+    assert_raises_kind_error('nil expected to be a kind of Struct') { Kind.of.Struct(nil) }
 
     # ---
 
@@ -202,13 +192,12 @@ class Kind::OfMethodsTest < Minitest::Test
 
     # ---
 
-    error = assert_raises(Kind::Error) { Kind.of.Struct(nil, or: 'default') }
-    assert_equal('"default" expected to be a kind of Struct', error.message)
+    assert_raises_kind_error('"default" expected to be a kind of Struct') { Kind.of.Struct(nil, or: 'default') }
   end
 
   def test_if_the_object_is_a_kind_of_enumerator
-    err = assert_raises(Kind::Error) { Kind.of.Enumerator([]) }
-    assert_equal('[] expected to be a kind of Enumerator', err.message)
+    assert_raises_kind_error('[] expected to be a kind of Enumerator') { Kind.of.Enumerator([]) }
+    assert_raises_kind_error('nil expected to be a kind of Enumerator') { Kind.of.Enumerator(nil) }
 
     # ---
 
@@ -220,13 +209,12 @@ class Kind::OfMethodsTest < Minitest::Test
 
     # ---
 
-    error = assert_raises(Kind::Error) { Kind.of.Enumerator(nil, or: 'default') }
-    assert_equal('"default" expected to be a kind of Enumerator', error.message)
+    assert_raises_kind_error('"default" expected to be a kind of Enumerator') { Kind.of.Enumerator(nil, or: 'default') }
   end
 
   def test_if_the_object_is_a_kind_of_method
-    err = assert_raises(Kind::Error) { Kind.of.Method([]) }
-    assert_equal('[] expected to be a kind of Method', err.message)
+    assert_raises_kind_error('[] expected to be a kind of Method') { Kind.of.Method([]) }
+    assert_raises_kind_error('nil expected to be a kind of Method') { Kind.of.Method(nil) }
 
     # ---
 
@@ -238,13 +226,12 @@ class Kind::OfMethodsTest < Minitest::Test
 
     # ---
 
-    error = assert_raises(Kind::Error) { Kind.of.Method(nil, or: 'default') }
-    assert_equal('"default" expected to be a kind of Method', error.message)
+    assert_raises_kind_error('"default" expected to be a kind of Method') { Kind.of.Method(nil, or: 'default') }
   end
 
   def test_if_the_object_is_a_kind_of_proc
-    err = assert_raises(Kind::Error) { Kind.of.Proc([]) }
-    assert_equal('[] expected to be a kind of Proc', err.message)
+    assert_raises_kind_error('[] expected to be a kind of Proc') { Kind.of.Proc([]) }
+    assert_raises_kind_error('nil expected to be a kind of Proc') { Kind.of.Proc(nil) }
 
     # ---
 
@@ -259,13 +246,12 @@ class Kind::OfMethodsTest < Minitest::Test
 
     # ---
 
-    error = assert_raises(Kind::Error) { Kind.of.Proc(nil, or: 'default') }
-    assert_equal('"default" expected to be a kind of Proc', error.message)
+    assert_raises_kind_error('"default" expected to be a kind of Proc') { Kind.of.Proc(nil, or: 'default') }
   end
 
   def test_if_the_object_is_a_kind_of_file
-    err = assert_raises(Kind::Error) { Kind.of.File([]) }
-    assert_equal('[] expected to be a kind of File', err.message)
+    assert_raises_kind_error('[] expected to be a kind of File') { Kind.of.File([]) }
+    assert_raises_kind_error('nil expected to be a kind of File') { Kind.of.File(nil) }
 
     # ---
 
@@ -277,13 +263,12 @@ class Kind::OfMethodsTest < Minitest::Test
 
     # ---
 
-    error = assert_raises(Kind::Error) { Kind.of.File(nil, or: 'default') }
-    assert_equal('"default" expected to be a kind of File', error.message)
+    assert_raises_kind_error('"default" expected to be a kind of File') { Kind.of.File(nil, or: 'default') }
   end
 
   def test_if_the_object_is_a_kind_of_boolean
-    err = assert_raises(Kind::Error) { Kind.of.Boolean(:a) }
-    assert_equal(':a expected to be a kind of Boolean', err.message)
+    assert_raises_kind_error('[] expected to be a kind of Boolean') { Kind.of.Boolean([]) }
+    assert_raises_kind_error('nil expected to be a kind of Boolean') { Kind.of.Boolean(nil) }
 
     # ---
 
@@ -295,8 +280,7 @@ class Kind::OfMethodsTest < Minitest::Test
 
     # ---
 
-    error = assert_raises(Kind::Error) { Kind.of.Boolean(nil, or: 'default') }
-    assert_equal('"default" expected to be a kind of Boolean', error.message)
+    assert_raises_kind_error('"default" expected to be a kind of Boolean') { Kind.of.Boolean(nil, or: 'default') }
   end
 
   def test_if_the_object_is_a_kind_of_lambda
@@ -305,11 +289,9 @@ class Kind::OfMethodsTest < Minitest::Test
 
     # ---
 
-    err1 = assert_raises(Kind::Error) { Kind.of.Lambda([]) }
-    assert_equal('[] expected to be a kind of Lambda', err1.message)
-
-    err2 = assert_raises(Kind::Error) { Kind.of.Lambda(sum) }
-    assert_match(/<Proc:.*> expected to be a kind of Lambda/, err2.message)
+    assert_raises_kind_error('[] expected to be a kind of Lambda') { Kind.of.Lambda([]) }
+    assert_raises_kind_error('nil expected to be a kind of Lambda') { Kind.of.Lambda(nil) }
+    assert_raises_kind_error(/<Proc:.*> expected to be a kind of Lambda/) { Kind.of.Lambda(sum) }
 
     # ---
 
@@ -319,13 +301,12 @@ class Kind::OfMethodsTest < Minitest::Test
 
     # ---
 
-    error = assert_raises(Kind::Error) { Kind.of.Lambda(nil, or: 'default') }
-    assert_equal('"default" expected to be a kind of Lambda', error.message)
+    assert_raises_kind_error('"default" expected to be a kind of Lambda') { Kind.of.Lambda(nil, or: 'default') }
   end
 
   def test_if_the_object_is_a_kind_of_queue
-    err = assert_raises(Kind::Error) { Kind.of.Queue([]) }
-    assert_equal('[] expected to be a kind of Queue', err.message)
+    assert_raises_kind_error('[] expected to be a kind of Queue') { Kind.of.Queue([]) }
+    assert_raises_kind_error('nil expected to be a kind of Queue') { Kind.of.Queue(nil) }
 
     # ---
 
@@ -337,15 +318,14 @@ class Kind::OfMethodsTest < Minitest::Test
 
     # ---
 
-    error = assert_raises(Kind::Error) { Kind.of.Queue(nil, or: 'default') }
-    assert_equal('"default" expected to be a kind of Queue', error.message)
+    assert_raises_kind_error('"default" expected to be a kind of Queue') { Kind.of.Queue(nil, or: 'default') }
   end
 
   # -- Modules
 
   def test_if_the_object_is_a_kind_of_enumerable
-    err = assert_raises(Kind::Error) { Kind.of.Enumerable(1) }
-    assert_equal('1 expected to be a kind of Enumerable', err.message)
+    assert_raises_kind_error('1 expected to be a kind of Enumerable') { Kind.of.Enumerable(1) }
+    assert_raises_kind_error('nil expected to be a kind of Enumerable') { Kind.of.Enumerable(nil) }
 
     # ---
 
@@ -357,13 +337,12 @@ class Kind::OfMethodsTest < Minitest::Test
 
     # ---
 
-    error = assert_raises(Kind::Error) { Kind.of.Enumerable(nil, or: 'default') }
-    assert_equal('"default" expected to be a kind of Enumerable', error.message)
+    assert_raises_kind_error('"default" expected to be a kind of Enumerable') { Kind.of.Enumerable(nil, or: 'default') }
   end
 
   def test_if_the_object_is_a_kind_of_comparable
-    err = assert_raises(Kind::Error) { Kind.of.Comparable([]) }
-    assert_equal('[] expected to be a kind of Comparable', err.message)
+    assert_raises_kind_error('[] expected to be a kind of Comparable') { Kind.of.Comparable([]) }
+    assert_raises_kind_error('nil expected to be a kind of Comparable') { Kind.of.Comparable(nil) }
 
     # ---
 
@@ -375,7 +354,6 @@ class Kind::OfMethodsTest < Minitest::Test
 
     # ---
 
-    error = assert_raises(Kind::Error) { Kind.of.Comparable(nil, or: []) }
-    assert_equal('[] expected to be a kind of Comparable', error.message)
+    assert_raises_kind_error('[] expected to be a kind of Comparable') { Kind.of.Comparable(nil, or: []) }
   end
 end

--- a/test/kind/of_types_with_a_namespace_test.rb
+++ b/test/kind/of_types_with_a_namespace_test.rb
@@ -21,13 +21,23 @@ class Kind::OfTypesWithANamespaceTest < Minitest::Test
 
     #---
 
-    err1 = assert_raises(Kind::Error) { Kind.of.Account::User([]) }
-    assert_equal('[] expected to be a kind of Account::User', err1.message)
+    assert_raises_kind_error('nil expected to be a kind of Account::User') do
+      Kind.of.Account::User(nil)
+    end
+
+    assert_raises_kind_error('[] expected to be a kind of Account::User') do
+      Kind.of.Account::User([])
+    end
 
     # -
 
-    err2 = assert_raises(Kind::Error) { Kind.of.Account::User::Membership([]) }
-    assert_equal('[] expected to be a kind of Account::User::Membership', err2.message)
+    assert_raises_kind_error('nil expected to be a kind of Account::User::Membership') do
+      Kind.of.Account::User::Membership(nil)
+    end
+
+    assert_raises_kind_error('[] expected to be a kind of Account::User::Membership') do
+      Kind.of.Account::User::Membership([])
+    end
 
     # ---
 
@@ -41,13 +51,15 @@ class Kind::OfTypesWithANamespaceTest < Minitest::Test
 
     # ---
 
-    error1 = assert_raises(Kind::Error) { Kind.of.Account::User::Membership(nil, or: 'default') }
-    assert_equal('"default" expected to be a kind of Account::User::Membership', error1.message)
+    assert_raises_kind_error('"default" expected to be a kind of Account::User') do
+      Kind.of.Account::User(nil, or: 'default')
+    end
 
     # -
 
-    error2 = assert_raises(Kind::Error) { Kind.of.Account::User::Membership(nil, or: 'default') }
-    assert_equal('"default" expected to be a kind of Account::User::Membership', error2.message)
+    assert_raises_kind_error('"default" expected to be a kind of Account::User::Membership') do
+      Kind.of.Account::User::Membership(nil, or: 'default')
+    end
 
     # ---
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,3 +9,17 @@ require "kind"
 
 require "minitest/pride"
 require "minitest/autorun"
+
+class Minitest::Test
+  def assert_raises_with_message(exception, msg, &block)
+    block.call
+  rescue exception => e
+    assert_match(msg, e.message)
+  else
+    raise "Expected to raise #{exception} w/ message #{msg}, none raised"
+  end
+
+  def assert_raises_kind_error(message, &block)
+    assert_raises_with_message(Kind::Error, message, &block)
+  end
+end


### PR DESCRIPTION
Before this pull request a type verification like `Kind.of.String(nil)` didn't raise a `Kind::Error`.