### PR TITLE
[1.6.0] Refine features and add dynamic type checkers

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,16 +21,22 @@ One of the goals of this project is to do simple type checking like `"some strin
   - [Verifying the kind of some object](#verifying-the-kind-of-some-object)
   - [Verifying the kind of some class/module](#verifying-the-kind-of-some-classmodule)
   - [How to create a new type checker?](#how-to-create-a-new-type-checker)
-    - [What happens if a custom type checker has a namespace?](#what-happens-if-a-custom-type-checker-has-a-namespace)
-- [Built-in type checkers](#built-in-type-checkers)
+    - [Creating/Verifiyng type checkers dynamically](#creatingverifiyng-type-checkers-dynamically)
+    - [Registering new (custom) type checkers](#registering-new-custom-type-checkers)
+      - [What happens if a custom type checker has a namespace?](#what-happens-if-a-custom-type-checker-has-a-namespace)
+- [Type checkers](#type-checkers)
+- [Classes' type checker](#classes-type-checker)
+  - [Module type checkers](#module-type-checkers)
   - [Special type checkers](#special-type-checkers)
     - [Kind.of](#kindof)
-    - [Kind.is](#kindis)
 - [Kind::Undefined](#kindundefined)
+  - [Kind.of.<Type>.or_undefined()](#kindoftypeor_undefined)
 - [Kind::Maybe](#kindmaybe)
   - [Kind::Maybe[] and Kind::Maybe#then](#kindmaybe-and-kindmaybethen)
   - [Kind::Maybe#try](#kindmaybetry)
+  - [Kind.of.Maybe()](#kindofmaybe)
   - [Kind::Optional](#kindoptional)
+  - [Kind::Empty](#kindempty)
 - [Development](#development)
 - [Contributing](#contributing)
 - [License](#license)
@@ -77,15 +83,12 @@ By default, basic verifications are strict. So, when you perform `Kind.of.Hash(v
 
 ```ruby
 Kind.of.Hash(nil)    # raise Kind::Error, "nil expected to be a kind of Hash"
-
 Kind.of.Hash('')     # raise Kind::Error, "'' expected to be a kind of Hash"
-
 Kind.of.Hash({a: 1}) # {a: 1}
 
 # ---
 
 Kind.of.Boolean(nil)   # raise Kind::Error, "nil expected to be a kind of Boolean"
-
 Kind.of.Boolean(true)  # true
 Kind.of.Boolean(false) # false
 ```
@@ -107,11 +110,8 @@ As an alternative syntax, you can use the `Kind::Of` instead of the method. e.g:
 But if you don't need a strict type verification, use the `.or_nil`method
 
 ```ruby
-Kind.of.Hash.or_nil('')
-# nil
-
-Kind.of.Hash.or_nil({a: 1})
-# {a: 1}
+Kind.of.Hash.or_nil('')     # nil
+Kind.of.Hash.or_nil({a: 1}) # {a: 1}
 
 # ---
 
@@ -130,6 +130,22 @@ Kind.of.Hash.instance?('')
 Kind.of.Boolean.instance?('')    # false
 Kind.of.Boolean.instance?(true)  # true
 Kind.of.Boolean.instance?(false) # true
+```
+
+Also, there are aliases to perform the strict type verification. e.g:
+
+```ruby
+Kind.of.Hash[nil]  # raise Kind::Error, "nil expected to be a kind of Hash"
+Kind.of.Hash['']   # raise Kind::Error, "'' expected to be a kind of Hash"
+Kind.of.Hash[a: 1] # {a: 1}
+Kind.of.Hash['', or: {}] # {}
+
+# or
+
+Kind.of.Hash.instance(nil)  # raise Kind::Error, "nil expected to be a kind of Hash"
+Kind.of.Hash.instance('')   # raise Kind::Error, "'' expected to be a kind of Hash"
+Kind.of.Hash.instance(a: 1) # {a: 1}
+Kind.of.Hash.instance('', or: {}) # {}
 ```
 
 ### Verifying the kind of some class/module
@@ -155,6 +171,57 @@ Kind.of.Hash.class?(ActiveSupport::HashWithIndifferentAccess) # true
 [⬆️ Back to Top](#table-of-contents-)
 
 ### How to create a new type checker?
+
+There are two ways to do this, you can create type checkers dynamically or register new ones.
+
+#### Creating/Verifiyng type checkers dynamically
+
+```ruby
+class User
+end
+
+user = User.new
+
+# ------------------------ #
+# Verifiyng the value kind #
+# ------------------------ #
+
+Kind.of(User, user) # <User ...>
+Kind.of(User, {})   # Kind::Error ({} expected to be a kind of User)
+
+Kind.of(Hash, {})   # {}
+Kind.of(Hash, user) # Kind::Error (<User ...> expected to be a kind of Hash)
+
+# ---------------------------------- #
+# Creating type checkers dynamically #
+# ---------------------------------- #
+
+kind_of_user = Kind.of(User)
+
+kind_of_user.or_nil({}) # nil
+
+kind_of_user.instance?({})   # false
+kind_of_user.instance?(User) # true
+
+kind_of_user.class?(Hash)  # false
+kind_of_user.class?(User)  # true
+
+# Create type checkers dynamically is cheap
+# because of a singleton object is created to be available for use.
+
+kind_of_user.object_id == Kind.of(User).object_id # true
+
+# --------------------------------------------- #
+# Kind.is() can be used to check a class/module #
+# --------------------------------------------- #
+
+class Admin < User
+end
+
+Kind.is(Admin, User) # true
+```
+
+#### Registering new (custom) type checkers
 
 Use `Kind::Types.add()`. e.g:
 
@@ -191,7 +258,7 @@ Kind.of.User.class?(User)  # true
 
 [⬆️ Back to Top](#table-of-contents-)
 
-#### What happens if a custom type checker has a namespace?
+##### What happens if a custom type checker has a namespace?
 
 The type checker will preserve the namespace. ;)
 
@@ -210,57 +277,63 @@ module Account
   end
 end
 
-Kind.of.Account::User(Account::User.new)  # #<Account::User:0x0000...>
+Kind.of.Account::User({}) # Kind::Error ({} expected to be a kind of Account::User)
 
-Kind.of.Account::User({})        # Kind::Error ({} expected to be a kind of Account::User)
+Kind.of.Account::User(Account::User.new)  # #<Account::User:0x0000...>
 
 Kind.of.Account::User.or_nil({}) # nil
 
-Kind.of.Account::User.instance?({})   # false
-Kind.of.Account::User.instance?(User) # true
+Kind.of.Account::User.instance?({})                # false
+Kind.of.Account::User.instance?(Account::User.new) # true
 
-Kind.of.Account::User.class?(Hash)  # false
-Kind.of.Account::User.class?(User)  # true
+Kind.of.Account::User.class?(Hash)           # false
+Kind.of.Account::User.class?(Account::User)  # true
 
 # ---
 
-Kind.of.Account::User::Membership(Account::User::Membership.new)  # #<Account::User::Membership:0x0000...>
+Kind.of.Account::User::Membership({}) # Kind::Error ({} expected to be a kind of Account::User::Membership)
 
-Kind.of.Account::User::Membership({})        # Kind::Error ({} expected to be a kind of Account::User::Membership)
+Kind.of.Account::User::Membership(Account::User::Membership.new)  # #<Account::User::Membership:0x0000...>
 
 Kind.of.Account::User::Membership.or_nil({}) # nil
 
-Kind.of.Account::User::Membership.instance?({})   # false
-Kind.of.Account::User::Membership.instance?(User) # true
+Kind.of.Account::User::Membership.instance?({})                            # false
+Kind.of.Account::User::Membership.instance?(Account::User::Membership.new) # true
 
-Kind.of.Account::User::Membership.class?(Hash)  # false
-Kind.of.Account::User::Membership.class?(User)  # true
+Kind.of.Account::User::Membership.class?(Hash)                      # false
+Kind.of.Account::User::Membership.class?(Account::User::Membership) # true
 ```
 
 [⬆️ Back to Top](#table-of-contents-)
 
-## Built-in type checkers
+## Type checkers
 
 The list of types (classes and modules) available to use with `Kind.of.*` or `Kind.is.*` are:
 
-| Classes    | Modules    |
-| ---------- | ---------- |
-| String     | Enumerable |
-| Symbol     | Comparable |
-| Numeric    |            |
-| Integer    |            |
-| Float      |            |
-| Regexp     |            |
-| Time       |            |
-| Array      |            |
-| Range      |            |
-| Hash       |            |
-| Struct     |            |
-| Enumerator |            |
-| Method     |            |
-| Proc       |            |
-| IO         |            |
-| File       |            |
+## Classes' type checker
+
+- `Kind.of.String`
+- `Kind.of.Symbol`
+- `Kind.of.Numeric`
+- `Kind.of.Integer`
+- `Kind.of.Float`
+- `Kind.of.Regexp`
+- `Kind.of.Time`
+- `Kind.of.Array`
+- `Kind.of.Range`
+- `Kind.of.Hash`
+- `Kind.of.Struct`
+- `Kind.of.Enumerator`
+- `Kind.of.Set`
+- `Kind.of.Method`
+- `Kind.of.Proc`
+- `Kind.of.IO`
+- `Kind.of.File`
+
+### Module type checkers
+
+- `Kind.of.Enumerable`
+- `Kind.of.Comparable`
 
 ### Special type checkers
 
@@ -270,14 +343,10 @@ The list of types (classes and modules) available to use with `Kind.of.*` or `Ki
 - `Kind.of.Module()`
 - `Kind.of.Lambda()`
 - `Kind.of.Boolean()`
-- `Kind.of.Callable()`
+- `Kind.of.Callable()`: verifies if the given value `respond_to?(:call)` or if it's a class/module and if its `public_instance_methods.include?(:call)`.
+- `Kind.of.Maybe()` or its alias `Kind.of.Optional()`
 
-#### Kind.is
-
-- `Kind.is.Class()`
-- `Kind.is.Module()`
-- `Kind.is.Boolean()`
-- `Kind.is.Callable()`: verifies if the given value `respond_to?(:call)` or if it's a class/module and if its `public_instance_methods.include?(:call)`.
+PS: Remember, you can use the `Kind.is.*` method to check if some given value is a class/module with all type checkers above.
 
 [⬆️ Back to Top](#table-of-contents-)
 
@@ -286,6 +355,15 @@ The list of types (classes and modules) available to use with `Kind.of.*` or `Ki
 The [`Kind::Undefined`](https://github.com/serradura/kind/blob/834f6b8ebdc737de8e5628986585f30c1a5aa41b/lib/kind/undefined.rb) constant is used as the default argument of type checkers. This is necessary [to know if no arguments were passed to the type check methods](https://github.com/serradura/kind/blob/834f6b8ebdc737de8e5628986585f30c1a5aa41b/lib/kind.rb#L45-L48). But, you can use it in your codebase too, especially if you need to distinguish the usage of `nil` as a method argument.
 
 If you are interested, check out [the tests](https://github.com/serradura/kind/blob/834f6b8ebdc737de8e5628986585f30c1a5aa41b/test/kind/undefined_test.rb) to understand its methods.
+
+### Kind.of.<Type>.or_undefined()
+
+If you interested in use `Kind::Undefined` you can use the method `.or_undefined` with any of the [available type checkers](#type-checkers). e.g:
+
+```ruby
+Kind.of.String.or_undefined(nil)         # Kind::Undefined
+Kind.of.String.or_undefined("something") # "something"
+```
 
 [⬆️ Back to Top](#table-of-contents-)
 
@@ -384,6 +462,36 @@ p Kind::Maybe[object].try { |value| value.upcase } # nil
 
 [⬆️ Back to Top](#table-of-contents-)
 
+### Kind.of.Maybe()
+
+You can use the `Kind.of.Maybe()` to know if the given value is a kind of `Kind::Maybe`object. e.g:
+
+```ruby
+def double(maybe_number)
+  Kind.of.Maybe(maybe_number)
+    .map { |value| value * 2 }
+    .value_or(0)
+end
+
+number = Kind::Maybe[4]
+
+puts double(number) # 8
+
+# -------------------------------------------------------#
+# All the type checker methods are available to use too. #
+# -------------------------------------------------------#
+
+Kind.of.Maybe.instance?(number) # true
+
+Kind.of.Maybe.or_nil(number) # <Kind::Maybe::Some @value=4 ...>
+
+Kind.of.Maybe.instance(number) # <Kind::Maybe::Some @value=4 ...>
+Kind.of.Maybe.instance(4) # Kind::Error (4 expected to be a kind of Kind::Maybe::Result)
+
+Kind.of.Maybe[number] # <Kind::Maybe::Some @value=4 ...>
+Kind.of.Maybe[4] # Kind::Error (4 expected to be a kind of Kind::Maybe::Result)
+```
+
 ### Kind::Optional
 
 The `Kind::Optional` constant is an alias for `Kind::Maybe`. e.g:
@@ -408,6 +516,55 @@ result2 =
 
 puts result2 # 35
 ```
+
+PS: The `Kind.of.Optional` is available to check if some value is a `Kind::Optional`.
+
+[⬆️ Back to Top](#table-of-contents-)
+
+### Kind::Empty
+
+There is a common need to define default argument values. In case you don't know, depending on the argument data type, when a  method is invoked a new object will be created in the program memory to fills some default argument value. e.g:
+
+```ruby
+def something(params = {})
+  params.object_id
+end
+
+puts something # 70312470300460
+puts something # 70312470295800
+puts something # 70312470278400
+puts something # 70312470273800
+```
+
+So, to avoid an unnecessary allocation in memory, the `kind` gem exposes some frozen objects to be used as default values.
+
+- `Kind::Empty::SET`
+- `Kind::Empty::HASH`
+- `Kind::Empty::ARRAY`
+- `Kind::Empty::STRING`
+
+Usage example:
+
+```ruby
+def do_something(value, with_options: Kind::Empty::HASH)
+  # ...
+end
+```
+
+One last thing, if there is no constant declared as Empty, the `kind` gem will define `Empty` as an alias for `Kind::Empty`. Knowing this, the previous example could be written like this:
+
+```ruby
+def do_something(value, with_options: Empty::HASH)
+  # ...
+end
+```
+
+Follows the list of constants, if the alias is available to be created:
+
+- `Empty::SET`
+- `Empty::HASH`
+- `Empty::ARRAY`
+- `Empty::STRING`
 
 [⬆️ Back to Top](#table-of-contents-)
 

--- a/lib/kind.rb
+++ b/lib/kind.rb
@@ -1,38 +1,67 @@
 # frozen_string_literal: true
 
 require 'kind/version'
+
+require 'kind/empty'
 require 'kind/undefined'
 require 'kind/maybe'
+
 require 'kind/error'
+require 'kind/of'
 require 'kind/is'
 require 'kind/checker'
-require 'kind/of'
 require 'kind/types'
 
 module Kind
-  def self.is; Is; end
-  def self.of; Of; end
+  WRONG_NUMBER_OF_ARGUMENTS = 'wrong number of arguments (given 1, expected 2)'.freeze
 
-  # -- Classes
-  [
-    String, Symbol, Numeric, Integer, Float, Regexp, Time,
-    Array, Range, Hash, Struct, Enumerator,
-    Method, Proc,
-    IO, File
-  ].each { |klass| Types.add(klass) }
+  private_constant :WRONG_NUMBER_OF_ARGUMENTS
 
-  Types.add(Queue, name: 'Queue'.freeze)
+  def self.is(expected = Undefined, object = Undefined)
+    return Is if expected == Undefined && object == Undefined
 
-  # -- Modules
-  [
-    Enumerable, Comparable
-  ].each { |klass| Types.add(klass) }
+    return Kind::Is.(expected, object) if object != Undefined
+
+    raise ArgumentError, WRONG_NUMBER_OF_ARGUMENTS
+  end
+
+  MODULE_OR_CLASS = 'Module/Class'.freeze
+
+  private_constant :MODULE_OR_CLASS
+
+  def self.of(kind = Undefined, object = Undefined)
+    return Of if kind == Undefined && object == Undefined
+
+    return Kind::Of.(kind, object) if object != Undefined
+
+    __checkers__[kind] ||= begin
+      kind_name = kind.name
+
+      if Kind::Of.const_defined?(kind_name, false)
+        Kind::Of.const_get(kind_name)
+      else
+        Checker.new(Kind::Of.(Module, kind, MODULE_OR_CLASS))
+      end
+    end
+  end
+
+  private_class_method def self.__checkers__
+    @__checkers__ ||= {}
+  end
 
   # --------------------- #
   # Special type checkers #
   # --------------------- #
 
   module Is
+    def self.Class(value)
+      value.is_a?(::Class)
+    end
+
+    def self.Module(value)
+      value == ::Module || (value.is_a?(::Module) && !self.Class(value))
+    end
+
     def self.Boolean(value)
       klass = Kind.of.Class(value)
       klass <= TrueClass || klass <= FalseClass
@@ -44,9 +73,73 @@ module Kind
   end
 
   module Of
+    # -- Class
+
+    def self.Class(object = Undefined)
+      return Class if object == Undefined
+
+      self.call(::Class, object)
+    end
+
+    const_set(:Class, ::Module.new do
+      extend Checkable
+
+      def self.__kind; ::Class; end
+
+      def self.class?(value); Kind::Is.Class(value); end
+
+      def self.instance?(value); class?(value); end
+    end)
+
+    # -- Module
+
+    def self.Module(object = Undefined)
+      return Module if object == Undefined
+
+      self.call(::Module, object)
+    end
+
+    const_set(:Module, ::Module.new do
+      extend Checkable
+
+      def self.__kind; ::Module; end
+
+      def self.__kind_error(value)
+        raise Kind::Error.new('Module'.freeze, value)
+      end
+
+      def self.__kind_of(value)
+        return value if Kind::Is.Module(value)
+
+        __kind_error(value)
+      end
+
+      def self.__kind_undefined(value)
+        __kind_error(Kind::Undefined) if value == Kind::Undefined
+
+        yield
+      end
+
+      def self.class?(value); Kind::Is.Module(value); end
+
+      def self.instance(value, options = Empty::HASH)
+        default = options[:or]
+
+        if ::Kind::Maybe::Value.none?(default)
+          __kind_undefined(value) { __kind_of(value) }
+        else
+          return value if instance?(value)
+
+          __kind_undefined(default) { __kind_of(default) }
+        end
+      end
+
+      def self.instance?(value); class?(value); end
+    end)
+
     # -- Boolean
 
-    def self.Boolean(object = Undefined, options = {})
+    def self.Boolean(object = Undefined, options = Empty::HASH)
       default = options[:or]
 
       return Kind::Of::Boolean if object == Undefined && default.nil?
@@ -59,20 +152,45 @@ module Kind
     end
 
     const_set(:Boolean, ::Module.new do
-      extend Checker
+      extend Checkable
 
       def self.__kind; [TrueClass, FalseClass].freeze; end
 
       def self.class?(value); Kind.is.Boolean(value); end
 
+      def self.instance(value, options= Empty::HASH)
+        default = options[:or]
+
+        if ::Kind::Maybe::Value.none?(default)
+          __kind_undefined(value) { Kind::Of::Boolean(value) }
+        else
+          return value if instance?(value)
+
+          __kind_undefined(default) { Kind::Of::Boolean(default) }
+        end
+      end
+
+      def self.__kind_undefined(value)
+        if value == Kind::Undefined
+          raise Kind::Error.new('Boolean'.freeze, Kind::Undefined)
+        else
+          yield
+        end
+      end
+
       def self.instance?(value);
         value.is_a?(TrueClass) || value.is_a?(FalseClass)
+      end
+
+      def self.or_undefined(value)
+        result = or_nil(value)
+        result.nil? ? Kind::Undefined : result
       end
     end)
 
     # -- Lambda
 
-    def self.Lambda(object = Undefined, options = {})
+    def self.Lambda(object = Undefined, options = Empty::HASH)
       default = options[:or]
 
       return Kind::Of::Lambda if object == Undefined && default.nil?
@@ -85,9 +203,29 @@ module Kind
     end
 
     const_set(:Lambda, ::Module.new do
-      extend Checker
+      extend Checkable
 
       def self.__kind; ::Proc; end
+
+      def self.instance(value, options = Empty::HASH)
+        default = options[:or]
+
+        if ::Kind::Maybe::Value.none?(default)
+          __kind_undefined(value) { Kind::Of::Lambda(value) }
+        else
+          return value if instance?(value)
+
+          __kind_undefined(default) { Kind::Of::Lambda(default) }
+        end
+      end
+
+      def self.__kind_undefined(value)
+        if value == Kind::Undefined
+          raise Kind::Error.new('Lambda'.freeze, Kind::Undefined)
+        else
+          yield
+        end
+      end
 
       def self.instance?(value)
         value.is_a?(__kind) && value.lambda?
@@ -96,7 +234,7 @@ module Kind
 
     # -- Callable
 
-    def self.Callable(object = Undefined, options = {})
+    def self.Callable(object = Undefined, options = Empty::HASH)
       default = options[:or]
 
       return Kind::Of::Callable if object == Undefined && default.nil?
@@ -109,7 +247,7 @@ module Kind
     end
 
     const_set(:Callable, ::Module.new do
-      extend Checker
+      extend Checkable
 
       def self.__kind; Object; end
 
@@ -117,9 +255,53 @@ module Kind
         Kind::Is::Callable(value)
       end
 
+      def self.instance(value, options = Empty::HASH)
+        default = options[:or]
+
+        if ::Kind::Maybe::Value.none?(default)
+          __kind_undefined(value) { Kind::Of::Callable(value) }
+        else
+          return value if instance?(value)
+
+          __kind_undefined(default) { Kind::Of::Callable(default) }
+        end
+      end
+
+      def self.__kind_undefined(value)
+        if value == Kind::Undefined
+          raise Kind::Error.new('Callable'.freeze, Kind::Undefined)
+        else
+          yield
+        end
+      end
+
       def self.instance?(value);
         value.respond_to?(:call)
       end
     end)
+
+    # ---------------------- #
+    # Built-in type checkers #
+    # ---------------------- #
+
+    # -- Classes
+    [
+      String, Symbol, Numeric, Integer, Float, Regexp, Time,
+      Array, Range, Hash, Struct, Enumerator, Set,
+      Method, Proc,
+      IO, File
+    ].each { |klass| Types.add(klass) }
+
+    Types.add(Queue, name: 'Queue'.freeze)
+
+    # -- Modules
+    [
+      Enumerable, Comparable
+    ].each { |klass| Types.add(klass) }
+
+    # -- Kind::Of::Maybe
+
+    Types.add(Kind::Maybe::Result, name: 'Maybe'.freeze)
+    Types.add(Kind::Maybe::Result, name: 'Optional'.freeze)
   end
 end

--- a/lib/kind/checker.rb
+++ b/lib/kind/checker.rb
@@ -1,9 +1,21 @@
 # frozen_string_literal: true
 
 module Kind
-  module Checker
+  module Checkable
     def class?(value)
-      Kind::Is.(__kind, value)
+      Kind::Is.__call__(__kind, value)
+    end
+
+    def instance(value, options = Empty::HASH)
+      default = options[:or]
+
+      return Kind::Of.(__kind, value) if ::Kind::Maybe::Value.none?(default)
+
+      instance?(value) ? value : Kind::Of.(__kind, default)
+    end
+
+    def [](value, options = options = Empty::HASH)
+      instance(value, options)
     end
 
     def instance?(value)
@@ -13,7 +25,21 @@ module Kind
     def or_nil(value)
       return value if instance?(value)
     end
+
+    def or_undefined(value)
+      or_nil(value) || Kind::Undefined
+    end
   end
 
-  private_constant :Checker
+  private_constant :Checkable
+
+  class Checker
+    include Checkable
+
+    attr_reader :__kind
+
+    def initialize(kind)
+      @__kind = kind
+    end
+  end
 end

--- a/lib/kind/empty.rb
+++ b/lib/kind/empty.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'set'
+
+module Kind
+  module Empty
+    SET = ::Set.new.freeze
+
+    HASH = {}.freeze
+
+    ARY = [].freeze
+    ARRAY = ARY
+
+    STR = ''.freeze
+    STRING = STR
+  end
+end
+
+unless defined?(Empty)
+  Empty = Kind::Empty
+end

--- a/lib/kind/error.rb
+++ b/lib/kind/error.rb
@@ -2,8 +2,8 @@
 
 module Kind
   class Error < TypeError
-    def initialize(klass, object)
-      super("#{object.inspect} expected to be a kind of #{klass}")
+    def initialize(kind_name, object)
+      super("#{object.inspect} expected to be a kind of #{kind_name}")
     end
   end
 end

--- a/lib/kind/is.rb
+++ b/lib/kind/is.rb
@@ -2,19 +2,14 @@
 
 module Kind
   module Is
-    def self.call(expected, value)
-      expected_mod = Kind::Of.Module(expected)
-      mod = Kind::Of.Module(value)
-
-      mod <= expected_mod || false
+    def self.call(expected, object)
+      __call__(Kind::Of.Module(expected), object)
     end
 
-    def self.Class(value)
-      value.is_a?(::Class)
-    end
+    def self.__call__(expected_kind, object)
+      kind = Kind::Of.Module(object)
 
-    def self.Module(value)
-      value == ::Module || (value.is_a?(::Module) && !self.Class(value))
+      kind <= expected_kind || false
     end
   end
 end

--- a/lib/kind/maybe.rb
+++ b/lib/kind/maybe.rb
@@ -19,18 +19,24 @@ module Kind
         @value = value
       end
 
-      def value_or(default, &block); end
+      def value_or(method_name = Undefined, &block)
+        raise NotImplementedError
+      end
 
-      def none?; end
+      def none?
+        raise NotImplementedError
+      end
 
       def some?; !none?; end
 
-      def map(&fn); end
+      def map(&fn)
+        raise NotImplementedError
+      end
 
-      def try(method_name, &block); end
+      def try(method_name = Undefined, &block)
+        raise NotImplementedError
+      end
     end
-
-    private_constant :Result
 
     class None < Result
       INVALID_DEFAULT_ARG = 'the default value must be defined as an argument or block'.freeze

--- a/lib/kind/of.rb
+++ b/lib/kind/of.rb
@@ -2,42 +2,10 @@
 
 module Kind
   module Of
-    def self.call(klass, object, name: nil)
-      return object if object.is_a?(klass)
+    def self.call(kind, object, kind_name = nil)
+      return object if kind === object
 
-      raise Kind::Error.new((name || klass.name), object)
+      raise Kind::Error.new(kind_name || kind.name, object)
     end
-
-    def self.Class(object = Undefined)
-      return Class if object == Undefined
-
-      self.call(::Class, object)
-    end
-
-    const_set(:Class, ::Module.new do
-      extend Checker
-
-      def self.__kind; ::Class; end
-
-      def self.class?(value); Kind::Is.Class(value); end
-
-      def self.instance?(value); class?(value); end
-    end)
-
-    def self.Module(object = Undefined)
-      return Module if object == Undefined
-
-      self.call(::Module, object)
-    end
-
-    const_set(:Module, ::Module.new do
-      extend Checker
-
-      def self.__kind; ::Module; end
-
-      def self.class?(value); Kind::Is.Module(value); end
-
-      def self.instance?(value); class?(value); end
-    end)
   end
 end

--- a/lib/kind/types.rb
+++ b/lib/kind/types.rb
@@ -7,12 +7,12 @@ module Kind
     COLONS = '::'.freeze
 
     KIND_OF = <<-RUBY
-      def self.%{method_name}(object = Undefined, options = {})
+      def self.%{method_name}(object = Undefined, options = Empty::HASH)
         default = options[:or]
 
         return Kind::Of::%{kind_name} if object == Undefined && default.nil?
 
-        Kind::Of.(::%{kind_name}, (object || default), name: "%{kind_name}".freeze)
+        Kind::Of.(::%{kind_name_to_check}, (object || default))
       end
     RUBY
 
@@ -20,7 +20,7 @@ module Kind
       def self.%{method_name}(value = Undefined)
         return Kind::Is::%{kind_name} if value == Undefined
 
-        Kind::Is.(::%{kind_name}, value)
+        Kind::Is.__call__(::%{kind_name_to_check}, value)
       end
     RUBY
 
@@ -30,21 +30,27 @@ module Kind
       kind_name = Kind.of.Module(kind).name
       checker = name ? Kind::Of.(String, name) : kind_name
 
-      case
-      when checker.include?(COLONS)
+      if checker.include?(COLONS)
         add_kind_with_namespace(checker, method_name: name)
       else
-        add_root(checker, kind_name, method_name: name, create_kind_is_mod: false)
+        add_root(checker, kind_name, method_name: name,
+                                     kind_name_to_check: kind_name,
+                                     create_kind_is_mod: false)
       end
     end
 
     private
 
-      def add_root(checker, kind_name, method_name:, create_kind_is_mod:)
-        root_checker = method_name ? method_name : checker
+      def add_root(checker, kind_name, method_name:, create_kind_is_mod:, kind_name_to_check: nil)
         root_kind_name = method_name ? method_name : kind_name
 
-        add_kind(root_checker, root_kind_name, Kind::Of, Kind::Is, create_kind_is_mod)
+        params = {
+          method_name: method_name ? method_name : checker,
+          kind_name: method_name ? method_name : kind_name,
+          kind_name_to_check: kind_name_to_check || root_kind_name
+        }
+
+        add_kind(params, Kind::Of, Kind::Is, create_kind_is_mod)
       end
 
       def add_kind_with_namespace(checker, method_name:)
@@ -70,23 +76,28 @@ module Kind
         checker = const_names[index]
         kind_name = const_names[0..index].join(COLONS)
 
-        add_kind(checker, kind_name, kind_of_mod, kind_is_mod, true)
-      end
-
-      def add_kind(checker, kind_name, kind_of_mod, kind_is_mod, create_kind_is_mod)
         params = { method_name: checker, kind_name: kind_name }
 
-        unless kind_of_mod.respond_to?(checker)
-          kind_checker = ::Module.new { extend Checker }
-          kind_checker.module_eval("def self.__kind; #{kind_name}; end")
+        add_kind(params, kind_of_mod, kind_is_mod, true)
+      end
+
+      def add_kind(params, kind_of_mod, kind_is_mod, create_kind_is_mod)
+        method_name = params[:method_name]
+
+        unless kind_of_mod.respond_to?(method_name)
+          kind_name = params[:kind_name]
+          params[:kind_name_to_check] ||= kind_name
+
+          kind_checker = ::Module.new { extend Checkable }
+          kind_checker.module_eval("def self.__kind; #{params[:kind_name_to_check]}; end")
 
           kind_of_mod.instance_eval(KIND_OF % params)
-          kind_of_mod.const_set(checker, kind_checker)
+          kind_of_mod.const_set(method_name, kind_checker)
         end
 
-        unless kind_is_mod.respond_to?(checker)
+        unless kind_is_mod.respond_to?(method_name)
           kind_is_mod.instance_eval(KIND_IS % params)
-          kind_is_mod.const_set(checker, Module.new) if create_kind_is_mod
+          kind_is_mod.const_set(method_name, Module.new) if create_kind_is_mod
         end
       end
   end

--- a/lib/kind/undefined.rb
+++ b/lib/kind/undefined.rb
@@ -3,7 +3,7 @@
 module Kind
   Undefined = Object.new.tap do |undefined|
     def undefined.inspect
-      @inspect ||= 'Undefined'.freeze
+      @inspect ||= 'Kind::Undefined'.freeze
     end
 
     def undefined.to_s

--- a/lib/kind/version.rb
+++ b/lib/kind/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Kind
-  VERSION = '1.5.0'
+  VERSION = '1.6.0'
 end

--- a/test/kind/is_class_test.rb
+++ b/test/kind/is_class_test.rb
@@ -92,6 +92,13 @@ class Kind::IsClassTest < Minitest::Test
     assert Kind.is.Enumerator(Class.new(Enumerator))
   end
 
+  def test_if_a_value_is_a_set_class_or_subclass
+    refute Kind.is.Set(Object)
+
+    assert Kind.is.Set(Set)
+    assert Kind.is.Set(Class.new(Set))
+  end
+
   def test_if_a_value_is_a_method_class_or_subclass
     refute Kind.is.Method(Object)
 
@@ -118,6 +125,29 @@ class Kind::IsClassTest < Minitest::Test
 
     assert Kind.is.File(File)
     assert Kind.is.File(Class.new(File))
+  end
+
+  def test_if_a_value_is_a_queue_class_or_subclass
+    refute Kind.is.Queue(Object)
+
+    assert Kind.is.Queue(Queue)
+    assert Kind.is.Queue(Class.new(Queue))
+  end
+
+  def test_if_a_value_is_a_maybe_class_or_subclass
+    refute Kind.is.Maybe(Object)
+
+    assert Kind.is.Maybe(Kind::Maybe::Result)
+    assert Kind.is.Maybe(Kind::Maybe::Some)
+    assert Kind.is.Maybe(Kind::Maybe::None)
+
+    # ---
+
+    refute Kind.is.Optional(Object)
+
+    assert Kind.is.Optional(Kind::Optional::Result)
+    assert Kind.is.Optional(Kind::Optional::Some)
+    assert Kind.is.Optional(Kind::Optional::None)
   end
 
   def test_if_a_value_is_a_boolean_class_or_subclass

--- a/test/kind/is_test.rb
+++ b/test/kind/is_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class Kind::IsTest < Minitest::Test
+  def test_the_method_call
+    assert Kind::Is.call(String, String)
+    assert Kind::Is.call(String, Class.new(String))
+
+    assert_raises_kind_error(given: '""', expected: 'Module') { Kind::Is.('', String) }
+  end
+
+  def test_the_kind_is_method
+    assert_same(Kind::Is, Kind.is)
+
+    assert Kind.is(String, String)
+    assert Kind.is(String, Class.new(String))
+
+    assert_raises_kind_error(given: '""', expected: 'Module') { Kind.is.('', String) }
+
+    # ---
+
+    assert_raises_with_message(
+      ArgumentError,
+      'wrong number of arguments (given 1, expected 2)'
+    ) { Kind.is(String) }
+  end
+end

--- a/test/kind/maybe_test.rb
+++ b/test/kind/maybe_test.rb
@@ -7,6 +7,36 @@ class Kind::MaybeTest < Minitest::Test
     assert_equal(0, Kind::Maybe.new(optional).value)
   end
 
+  def test_maybe_result
+    object = Object.new
+
+    maybe_result = Kind::Maybe::Result.new(object)
+
+    assert_same(object, maybe_result.value)
+
+    assert_raises(NotImplementedError) { maybe_result.none? }
+    assert_raises(NotImplementedError) { maybe_result.some? }
+    assert_raises(NotImplementedError) { maybe_result.map { 0 } }
+    assert_raises(NotImplementedError) { maybe_result.try(:anything) }
+    assert_raises(NotImplementedError) { maybe_result.try { |value| value.anything } }
+    assert_raises(NotImplementedError) { maybe_result.value_or(2) }
+    assert_raises(NotImplementedError) { maybe_result.value_or { 3 } }
+  end
+
+  def test_maybe_when_some
+    assert_predicate(Kind::Maybe.new(2), :some?)
+
+    refute_predicate(Kind::Maybe.new(nil), :some?)
+    refute_predicate(Kind::Maybe.new(Kind::Undefined), :some?)
+  end
+
+  def test_maybe_when_none
+    assert_predicate(Kind::Maybe.new(nil), :none?)
+    assert_predicate(Kind::Maybe.new(Kind::Undefined), :none?)
+
+    refute_predicate(Kind::Maybe.new(1), :none?)
+  end
+
   def test_maybe_value
     optional1 = Kind::Maybe.new(2)
 
@@ -57,20 +87,6 @@ class Kind::MaybeTest < Minitest::Test
       ArgumentError,
       'the default value must be defined as an argument or block'
     ) { optional3.value_or }
-  end
-
-  def test_maybe_when_some
-    assert_predicate(Kind::Maybe.new(2), :some?)
-
-    refute_predicate(Kind::Maybe.new(nil), :some?)
-    refute_predicate(Kind::Maybe.new(Kind::Undefined), :some?)
-  end
-
-  def test_maybe_when_none
-    assert_predicate(Kind::Maybe.new(nil), :none?)
-    assert_predicate(Kind::Maybe.new(Kind::Undefined), :none?)
-
-    refute_predicate(Kind::Maybe.new(1), :none?)
   end
 
   def test_maybe_map_when_none

--- a/test/kind/of_checkers_test.rb
+++ b/test/kind/of_checkers_test.rb
@@ -4,34 +4,80 @@ class Kind::OfCheckersTest < Minitest::Test
   # -- Classes
 
   def test_if_a_value_is_a_kind_of_class
+    assert_raises_kind_error(given: 'nil', expected: 'Class') { Kind.of.Class.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Class') { Kind.of.Class.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: ':a', expected: 'Class') { Kind.of.Class.instance(:a) }
+    assert_raises_kind_error(given: 'Enumerable', expected: 'Class') { Kind.of.Class.instance(Enumerable) }
+    assert_equal(String, Kind.of.Class.instance(String))
+    assert_equal(Symbol, Kind.of.Class.instance(Symbol, or: String))
+    assert_equal(String, Kind.of.Class.instance(nil, or: String))
+    assert_equal(String, Kind.of.Class.instance(Kind::Undefined, or: String))
+    assert_raises_kind_error(given: 'nil', expected: 'Class') { Kind.of.Class.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Class') { Kind.of.Class.instance(Kind::Undefined, or: nil) }
+
     refute Kind.of.Class.instance?([1])
     refute Kind.of.Class.instance?(Enumerable)
     assert Kind.of.Class.instance?(String)
-    assert Kind.of.Class.class?(Class.new.tap { |klass| klass.send(:include, Enumerable) })
 
-    refute Kind.of.Class.class?(Enumerable)
+    assert Kind.of.Class.class?(String)
     assert Kind.of.Class.class?(Class.new.tap { |klass| klass.send(:include, Enumerable) })
+    refute Kind.of.Class.class?(Enumerable)
 
     assert_nil Kind.of.Class.or_nil('')
     assert_equal(String, Kind.of.Class.or_nil(String))
 
+    assert_kind_undefined Kind.of.Class.or_undefined('')
+    assert_equal(String, Kind.of.Class.or_undefined(String))
+
     # ---
+
+    assert_raises_kind_error(given: 'nil', expected: 'Class') { Kind::Of::Class.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Class') { Kind::Of::Class.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: ':a', expected: 'Class') { Kind::Of::Class.instance(:a) }
+    assert_raises_kind_error(given: 'Enumerable', expected: 'Class') { Kind::Of::Class.instance(Enumerable) }
+    assert_equal(String, Kind::Of::Class.instance(String))
+    assert_equal(Symbol, Kind::Of::Class.instance(Symbol, or: String))
+    assert_equal(String, Kind::Of::Class.instance(nil, or: String))
+    assert_equal(String, Kind::Of::Class.instance(Kind::Undefined, or: String))
+    assert_raises_kind_error(given: 'nil', expected: 'Class') { Kind::Of::Class.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Class') { Kind::Of::Class.instance(Kind::Undefined, or: nil) }
 
     refute Kind::Of::Class.instance?([1])
     refute Kind::Of::Class.instance?(Enumerable)
     assert Kind::Of::Class.instance?(String)
-    assert Kind::Of::Class.class?(Class.new.tap { |klass| klass.send(:include, Enumerable) })
 
-    refute Kind::Of::Class.class?(Enumerable)
+    assert Kind::Of::Class.class?(String)
     assert Kind::Of::Class.class?(Class.new.tap { |klass| klass.send(:include, Enumerable) })
+    refute Kind::Of::Class.class?(Enumerable)
 
     assert_nil Kind::Of::Class.or_nil('')
     assert_equal(String, Kind::Of::Class.or_nil(String))
+
+    assert_kind_undefined Kind::Of::Class.or_undefined('')
+    assert_equal(String, Kind::Of::Class.or_undefined(String))
+
+    # --
+
+    assert_same(Kind::Of::Class, Kind.of.Class)
+
+    Kind::Of::Class.stub(:instance, -> (obj, opt) { [obj, opt] }) do
+      assert_equal([String, {}], Kind.of.Class[String])
+    end
   end
 
   # --- String
 
   def test_if_a_value_is_a_kind_of_string
+    assert_raises_kind_error(given: 'nil', expected: 'String') { Kind.of.String.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'String') { Kind.of.String.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: ':a', expected: 'String') { Kind.of.String.instance(:a) }
+    assert_equal('a', Kind.of.String.instance('a'))
+    assert_equal('b', Kind.of.String.instance(:a, or: 'b'))
+    assert_equal('c', Kind.of.String.instance(nil, or: 'c'))
+    assert_equal('d', Kind.of.String.instance(Kind::Undefined, or: 'd'))
+    assert_raises_kind_error(given: 'nil', expected: 'String') { Kind.of.String.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'String') { Kind.of.String.instance(Kind::Undefined, or: nil) }
+
     refute Kind.of.String.instance?({})
     assert Kind.of.String.instance?('')
 
@@ -42,7 +88,20 @@ class Kind::OfCheckersTest < Minitest::Test
     assert_nil Kind.of.String.or_nil({})
     assert_equal('a', Kind.of.String.or_nil('a'))
 
+    assert_kind_undefined Kind.of.String.or_undefined({})
+    assert_equal('a', Kind.of.String.or_undefined('a'))
+
     # ---
+
+    assert_raises_kind_error(given: 'nil', expected: 'String') { Kind::Of::String.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'String') { Kind::Of::String.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: ':a', expected: 'String') { Kind::Of::String.instance(:a) }
+    assert_equal('a', Kind::Of::String.instance('a'))
+    assert_equal('b', Kind::Of::String.instance(:a, or: 'b'))
+    assert_equal('c', Kind::Of::String.instance(nil, or: 'c'))
+    assert_equal('d', Kind::Of::String.instance(Kind::Undefined, or: 'd'))
+    assert_raises_kind_error(given: 'nil', expected: 'String') { Kind::Of::String.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'String') { Kind::Of::String.instance(Kind::Undefined, or: nil) }
 
     refute Kind::Of::String.instance?({})
     assert Kind::Of::String.instance?('')
@@ -53,11 +112,32 @@ class Kind::OfCheckersTest < Minitest::Test
 
     assert_nil Kind::Of::String.or_nil({})
     assert_equal('a', Kind::Of::String.or_nil('a'))
+
+    assert_kind_undefined Kind::Of::String.or_undefined({})
+    assert_equal('a', Kind::Of::String.or_undefined('a'))
+
+    # --
+
+    assert_same(Kind::Of::String, Kind.of.String)
+
+    Kind::Of::String.stub(:instance, -> (obj, opt) { [obj, opt] }) do
+      assert_equal(['a', {}], Kind.of.String['a'])
+    end
   end
 
   # --- Symbol
 
   def test_if_a_value_is_a_kind_of_symbol
+    assert_raises_kind_error(given: 'nil', expected: 'Symbol') { Kind.of.Symbol.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Symbol') { Kind.of.Symbol.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1', expected: 'Symbol') { Kind.of.Symbol.instance(1) }
+    assert_equal(:a, Kind.of.Symbol.instance(:a))
+    assert_equal(:b, Kind.of.Symbol.instance('a', or: :b))
+    assert_equal(:c, Kind.of.Symbol.instance(nil, or: :c))
+    assert_equal(:d, Kind.of.Symbol.instance(Kind::Undefined, or: :d))
+    assert_raises_kind_error(given: 'nil', expected: 'Symbol') { Kind.of.Symbol.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Symbol') { Kind.of.Symbol.instance(Kind::Undefined, or: nil) }
+
     refute Kind.of.Symbol.instance?({})
     assert Kind.of.Symbol.instance?(:a)
 
@@ -68,7 +148,20 @@ class Kind::OfCheckersTest < Minitest::Test
     assert_nil Kind.of.Symbol.or_nil({})
     assert_equal(:a, Kind.of.Symbol.or_nil(:a))
 
+    assert_kind_undefined Kind.of.Symbol.or_undefined({})
+    assert_equal(:a, Kind.of.Symbol.or_undefined(:a))
+
     # ---
+
+    assert_raises_kind_error(given: 'nil', expected: 'Symbol') { Kind::Of::Symbol.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Symbol') { Kind::Of::Symbol.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1', expected: 'Symbol') { Kind::Of::Symbol.instance(1) }
+    assert_equal(:a, Kind::Of::Symbol.instance(:a))
+    assert_equal(:b, Kind::Of::Symbol.instance('a', or: :b))
+    assert_equal(:c, Kind::Of::Symbol.instance(nil, or: :c))
+    assert_equal(:d, Kind::Of::Symbol.instance(Kind::Undefined, or: :d))
+    assert_raises_kind_error(given: 'nil', expected: 'Symbol') { Kind::Of::Symbol.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Symbol') { Kind::Of::Symbol.instance(Kind::Undefined, or: nil) }
 
     refute Kind::Of::Symbol.instance?({})
     assert Kind::Of::Symbol.instance?(:a)
@@ -79,11 +172,32 @@ class Kind::OfCheckersTest < Minitest::Test
 
     assert_nil Kind::Of::Symbol.or_nil({})
     assert_equal(:a, Kind::Of::Symbol.or_nil(:a))
+
+    assert_kind_undefined Kind::Of::Symbol.or_undefined({})
+    assert_equal(:a, Kind::Of::Symbol.or_undefined(:a))
+
+    # --
+
+    assert_same(Kind::Of::Symbol, Kind.of.Symbol)
+
+    Kind::Of::Symbol.stub(:instance, -> (obj, opt) { [obj, opt] }) do
+      assert_equal([:a, {}], Kind.of.Symbol[:a])
+    end
   end
 
   # --- Numeric
 
   def test_if_a_value_is_a_kind_of_numeric
+    assert_raises_kind_error(given: 'nil', expected: 'Numeric') { Kind.of.Numeric.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Numeric') { Kind.of.Numeric.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: ':a', expected: 'Numeric') { Kind.of.Numeric.instance(:a) }
+    assert_equal(1, Kind.of.Numeric.instance(1))
+    assert_equal(1.0, Kind.of.Numeric.instance('a', or: 1.0))
+    assert_equal(2, Kind.of.Numeric.instance(nil, or: 2))
+    assert_equal(3.0, Kind.of.Numeric.instance(Kind::Undefined, or: 3.0))
+    assert_raises_kind_error(given: 'nil', expected: 'Numeric') { Kind.of.Numeric.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Numeric') { Kind.of.Numeric.instance(Kind::Undefined, or: nil) }
+
     refute Kind.of.Numeric.instance?({})
     assert Kind.of.Numeric.instance?(1)
     assert Kind.of.Numeric.instance?(1.0)
@@ -98,7 +212,21 @@ class Kind::OfCheckersTest < Minitest::Test
     assert_equal(1, Kind.of.Numeric.or_nil(1))
     assert_equal(1.0, Kind.of.Numeric.or_nil(1.0))
 
+    assert_kind_undefined Kind.of.Numeric.or_undefined({})
+    assert_equal(1, Kind.of.Numeric.or_undefined(1))
+    assert_equal(1.0, Kind.of.Numeric.or_undefined(1.0))
+
     # ---
+
+    assert_raises_kind_error(given: 'nil', expected: 'Numeric') { Kind::Of::Numeric.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Numeric') { Kind::Of::Numeric.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: ':a', expected: 'Numeric') { Kind::Of::Numeric.instance(:a) }
+    assert_equal(1, Kind::Of::Numeric.instance(1))
+    assert_equal(1.0, Kind::Of::Numeric.instance('a', or: 1.0))
+    assert_equal(2, Kind::Of::Numeric.instance(nil, or: 2))
+    assert_equal(3.0, Kind::Of::Numeric.instance(Kind::Undefined, or: 3.0))
+    assert_raises_kind_error(given: 'nil', expected: 'Numeric') { Kind::Of::Numeric.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Numeric') { Kind::Of::Numeric.instance(Kind::Undefined, or: nil) }
 
     refute Kind::Of::Numeric.instance?({})
     assert Kind::Of::Numeric.instance?(1)
@@ -113,11 +241,33 @@ class Kind::OfCheckersTest < Minitest::Test
     assert_nil Kind::Of::Numeric.or_nil({})
     assert_equal(1, Kind::Of::Numeric.or_nil(1))
     assert_equal(1.0, Kind::Of::Numeric.or_nil(1.0))
+
+    assert_kind_undefined Kind::Of::Numeric.or_undefined({})
+    assert_equal(1, Kind::Of::Numeric.or_undefined(1))
+    assert_equal(1.0, Kind::Of::Numeric.or_undefined(1.0))
+
+    # --
+
+    assert_same(Kind::Of::Numeric, Kind.of.Numeric)
+
+    Kind::Of::Numeric.stub(:instance, -> (obj, opt) { [obj, opt] }) do
+      assert_equal([1, {}], Kind.of.Numeric[1])
+    end
   end
 
   # --- Integer
 
   def test_if_a_value_is_a_kind_of_integer
+    assert_raises_kind_error(given: 'nil', expected: 'Integer') { Kind.of.Integer.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Integer') { Kind.of.Integer.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1.0', expected: 'Integer') { Kind.of.Integer.instance(1.0) }
+    assert_equal(1, Kind.of.Integer.instance(1))
+    assert_equal(2, Kind.of.Integer.instance(nil, or: 2))
+    assert_equal(3, Kind.of.Integer.instance(3.0, or: 3))
+    assert_equal(4, Kind.of.Integer.instance(Kind::Undefined, or: 4))
+    assert_raises_kind_error(given: 'nil', expected: 'Integer') { Kind.of.Integer.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Integer') { Kind.of.Integer.instance(Kind::Undefined, or: nil) }
+
     refute Kind.of.Integer.instance?({})
     assert Kind.of.Integer.instance?(1)
 
@@ -129,7 +279,21 @@ class Kind::OfCheckersTest < Minitest::Test
     assert_nil Kind.of.Integer.or_nil(1.0)
     assert_equal(1, Kind.of.Integer.or_nil(1))
 
+    assert_kind_undefined Kind.of.Integer.or_undefined({})
+    assert_kind_undefined Kind.of.Integer.or_undefined(1.0)
+    assert_equal(1, Kind.of.Integer.or_undefined(1))
+
     # ---
+
+    assert_raises_kind_error(given: 'nil', expected: 'Integer') { Kind::Of::Integer.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Integer') { Kind::Of::Integer.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1.0', expected: 'Integer') { Kind::Of::Integer.instance(1.0) }
+    assert_equal(1, Kind::Of::Integer.instance(1))
+    assert_equal(2, Kind::Of::Integer.instance(nil, or: 2))
+    assert_equal(3, Kind::Of::Integer.instance(3.0, or: 3))
+    assert_equal(4, Kind::Of::Integer.instance(Kind::Undefined, or: 4))
+    assert_raises_kind_error(given: 'nil', expected: 'Integer') { Kind::Of::Integer.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Integer') { Kind::Of::Integer.instance(Kind::Undefined, or: nil) }
 
     refute Kind::Of::Integer.instance?({})
     assert Kind::Of::Integer.instance?(1)
@@ -141,11 +305,33 @@ class Kind::OfCheckersTest < Minitest::Test
     assert_nil Kind::Of::Integer.or_nil({})
     assert_nil Kind::Of::Integer.or_nil(1.0)
     assert_equal(1, Kind::Of::Integer.or_nil(1))
+
+    assert_kind_undefined Kind::Of::Integer.or_undefined({})
+    assert_kind_undefined Kind::Of::Integer.or_undefined(1.0)
+    assert_equal(1, Kind::Of::Integer.or_undefined(1))
+
+    # --
+
+    assert_same(Kind::Of::Integer, Kind.of.Integer)
+
+    Kind::Of::Integer.stub(:instance, -> (obj, opt) { [obj, opt] }) do
+      assert_equal([1, {}], Kind.of.Integer[1])
+    end
   end
 
   # --- Float
 
   def test_if_a_value_is_a_kind_of_Float
+    assert_raises_kind_error(given: 'nil', expected: 'Float') { Kind.of.Float.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Float') { Kind.of.Float.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1', expected: 'Float') { Kind.of.Float.instance(1) }
+    assert_equal(1.0, Kind.of.Float.instance(1.0))
+    assert_equal(2.0, Kind.of.Float.instance(nil, or: 2.0))
+    assert_equal(3.0, Kind.of.Float.instance(3, or: 3.0))
+    assert_equal(4.0, Kind.of.Float.instance(Kind::Undefined, or: 4.0))
+    assert_raises_kind_error(given: 'nil', expected: 'Float') { Kind.of.Float.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Float') { Kind.of.Float.instance(Kind::Undefined, or: nil) }
+
     refute Kind.of.Float.instance?({})
     assert Kind.of.Float.instance?(1.0)
 
@@ -157,7 +343,21 @@ class Kind::OfCheckersTest < Minitest::Test
     assert_nil Kind.of.Float.or_nil(1)
     assert_equal(1.0, Kind.of.Float.or_nil(1.0))
 
+    assert_kind_undefined Kind.of.Float.or_undefined({})
+    assert_kind_undefined Kind.of.Float.or_undefined(1)
+    assert_equal(1.0, Kind.of.Float.or_undefined(1.0))
+
     # ---
+
+    assert_raises_kind_error(given: 'nil', expected: 'Float') { Kind::Of::Float.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Float') { Kind::Of::Float.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1', expected: 'Float') { Kind::Of::Float.instance(1) }
+    assert_equal(1.0, Kind::Of::Float.instance(1.0))
+    assert_equal(2.0, Kind::Of::Float.instance(nil, or: 2.0))
+    assert_equal(3.0, Kind::Of::Float.instance(3, or: 3.0))
+    assert_equal(4.0, Kind::Of::Float.instance(Kind::Undefined, or: 4.0))
+    assert_raises_kind_error(given: 'nil', expected: 'Float') { Kind::Of::Float.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Float') { Kind::Of::Float.instance(Kind::Undefined, or: nil) }
 
     refute Kind::Of::Float.instance?({})
     assert Kind::Of::Float.instance?(1.0)
@@ -169,11 +369,33 @@ class Kind::OfCheckersTest < Minitest::Test
     assert_nil Kind::Of::Float.or_nil({})
     assert_nil Kind::Of::Float.or_nil(1)
     assert_equal(1.0, Kind::Of::Float.or_nil(1.0))
+
+    assert_kind_undefined Kind::Of::Float.or_undefined({})
+    assert_kind_undefined Kind::Of::Float.or_undefined(1)
+    assert_equal(1.0, Kind::Of::Float.or_undefined(1.0))
+
+    # --
+
+    assert_same(Kind::Of::Float, Kind.of.Float)
+
+    Kind::Of::Float.stub(:instance, -> (obj, opt) { [obj, opt] }) do
+      assert_equal([1.0, {}], Kind.of.Float[1.0])
+    end
   end
 
   # --- Regexp
 
   def test_if_a_value_is_a_kind_of_regexp
+    assert_raises_kind_error(given: 'nil', expected: 'Regexp') { Kind.of.Regexp.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Regexp') { Kind.of.Regexp.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1', expected: 'Regexp') { Kind.of.Regexp.instance(1) }
+    assert_equal(/1.0/, Kind.of.Regexp.instance(/1.0/))
+    assert_equal(/1.0/, Kind.of.Regexp.instance(nil, or: /1.0/))
+    assert_equal(/1.0/, Kind.of.Regexp.instance(3, or: /1.0/))
+    assert_equal(/1.0/, Kind.of.Regexp.instance(Kind::Undefined, or: /1.0/))
+    assert_raises_kind_error(given: 'nil', expected: 'Regexp') { Kind.of.Regexp.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Regexp') { Kind.of.Regexp.instance(Kind::Undefined, or: nil) }
+
     refute Kind.of.Regexp.instance?({})
     assert Kind.of.Regexp.instance?(/1.0/)
 
@@ -184,7 +406,20 @@ class Kind::OfCheckersTest < Minitest::Test
     assert_nil Kind.of.Regexp.or_nil({})
     assert_equal(/1.0/, Kind.of.Regexp.or_nil(/1.0/))
 
+    assert_kind_undefined Kind.of.Regexp.or_undefined({})
+    assert_equal(/1.0/, Kind.of.Regexp.or_undefined(/1.0/))
+
     # ---
+
+    assert_raises_kind_error(given: 'nil', expected: 'Regexp') { Kind::Of::Regexp.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Regexp') { Kind::Of::Regexp.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1', expected: 'Regexp') { Kind::Of::Regexp.instance(1) }
+    assert_equal(/1.0/, Kind::Of::Regexp.instance(/1.0/))
+    assert_equal(/1.0/, Kind::Of::Regexp.instance(nil, or: /1.0/))
+    assert_equal(/1.0/, Kind::Of::Regexp.instance(3, or: /1.0/))
+    assert_equal(/1.0/, Kind::Of::Regexp.instance(Kind::Undefined, or: /1.0/))
+    assert_raises_kind_error(given: 'nil', expected: 'Regexp') { Kind::Of::Regexp.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Regexp') { Kind::Of::Regexp.instance(Kind::Undefined, or: nil) }
 
     refute Kind::Of::Regexp.instance?({})
     assert Kind::Of::Regexp.instance?(/1.0/)
@@ -195,12 +430,33 @@ class Kind::OfCheckersTest < Minitest::Test
 
     assert_nil Kind::Of::Regexp.or_nil({})
     assert_equal(/1.0/, Kind::Of::Regexp.or_nil(/1.0/))
+
+    assert_kind_undefined Kind::Of::Regexp.or_undefined({})
+    assert_equal(/1.0/, Kind::Of::Regexp.or_undefined(/1.0/))
+
+    # --
+
+    assert_same(Kind::Of::Regexp, Kind.of.Regexp)
+
+    Kind::Of::Regexp.stub(:instance, -> (obj, opt) { [obj, opt] }) do
+      assert_equal([/1.0/, {}], Kind.of.Regexp[/1.0/])
+    end
   end
 
   # --- Time
 
   def test_if_a_value_is_a_kind_of_time
     now = Time.now
+
+    assert_raises_kind_error(given: 'nil', expected: 'Time') { Kind.of.Time.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Time') { Kind.of.Time.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1', expected: 'Time') { Kind.of.Time.instance(1) }
+    assert_equal(now, Kind.of.Time.instance(now))
+    assert_equal(now, Kind.of.Time.instance(nil, or: now))
+    assert_equal(now, Kind.of.Time.instance(3, or: now))
+    assert_equal(now, Kind.of.Time.instance(Kind::Undefined, or: now))
+    assert_raises_kind_error(given: 'nil', expected: 'Time') { Kind.of.Time.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Time') { Kind.of.Time.instance(Kind::Undefined, or: nil) }
 
     refute Kind.of.Time.instance?({})
     assert Kind.of.Time.instance?(now)
@@ -212,7 +468,20 @@ class Kind::OfCheckersTest < Minitest::Test
     assert_nil Kind.of.Time.or_nil({})
     assert_equal(now, Kind.of.Time.or_nil(now))
 
+    assert_kind_undefined Kind.of.Time.or_undefined({})
+    assert_equal(now, Kind.of.Time.or_undefined(now))
+
     # ---
+
+    assert_raises_kind_error(given: 'nil', expected: 'Time') { Kind::Of::Time.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Time') { Kind::Of::Time.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1', expected: 'Time') { Kind::Of::Time.instance(1) }
+    assert_equal(now, Kind::Of::Time.instance(now))
+    assert_equal(now, Kind::Of::Time.instance(nil, or: now))
+    assert_equal(now, Kind::Of::Time.instance(3, or: now))
+    assert_equal(now, Kind::Of::Time.instance(Kind::Undefined, or: now))
+    assert_raises_kind_error(given: 'nil', expected: 'Time') { Kind::Of::Time.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Time') { Kind::Of::Time.instance(Kind::Undefined, or: nil) }
 
     refute Kind::Of::Time.instance?({})
     assert Kind::Of::Time.instance?(now)
@@ -223,11 +492,32 @@ class Kind::OfCheckersTest < Minitest::Test
 
     assert_nil Kind::Of::Time.or_nil({})
     assert_equal(now, Kind::Of::Time.or_nil(now))
+
+    assert_kind_undefined Kind::Of::Time.or_undefined({})
+    assert_equal(now, Kind::Of::Time.or_undefined(now))
+
+    # --
+
+    assert_same(Kind::Of::Time, Kind.of.Time)
+
+    Kind::Of::Time.stub(:instance, -> (obj, opt) { [obj, opt] }) do
+      assert_equal([now, {}], Kind.of.Time[now])
+    end
   end
 
   # --- Array
 
   def test_if_a_value_is_a_kind_of_array
+    assert_raises_kind_error(given: 'nil', expected: 'Array') { Kind.of.Array.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Array') { Kind.of.Array.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1', expected: 'Array') { Kind.of.Array.instance(1) }
+    assert_equal([], Kind.of.Array.instance([]))
+    assert_equal([], Kind.of.Array.instance(nil, or: []))
+    assert_equal([], Kind.of.Array.instance(3, or: []))
+    assert_equal([], Kind.of.Array.instance(Kind::Undefined, or: []))
+    assert_raises_kind_error(given: 'nil', expected: 'Array') { Kind.of.Array.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Array') { Kind.of.Array.instance(Kind::Undefined, or: nil) }
+
     refute Kind.of.Array.instance?({})
     assert Kind.of.Array.instance?([])
 
@@ -237,7 +527,20 @@ class Kind::OfCheckersTest < Minitest::Test
     assert_nil Kind.of.Array.or_nil({})
     assert_equal([1], Kind.of.Array.or_nil([1]))
 
+    assert_kind_undefined Kind.of.Array.or_undefined({})
+    assert_equal([2], Kind.of.Array.or_undefined([2]))
+
     # ---
+
+    assert_raises_kind_error(given: 'nil', expected: 'Array') { Kind::Of::Array.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Array') { Kind::Of::Array.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1', expected: 'Array') { Kind::Of::Array.instance(1) }
+    assert_equal([], Kind::Of::Array.instance([]))
+    assert_equal([], Kind::Of::Array.instance(nil, or: []))
+    assert_equal([], Kind::Of::Array.instance(3, or: []))
+    assert_equal([], Kind::Of::Array.instance(Kind::Undefined, or: []))
+    assert_raises_kind_error(given: 'nil', expected: 'Array') { Kind::Of::Array.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Array') { Kind::Of::Array.instance(Kind::Undefined, or: nil) }
 
     refute Kind::Of::Array.instance?({})
     assert Kind::Of::Array.instance?([])
@@ -248,12 +551,33 @@ class Kind::OfCheckersTest < Minitest::Test
 
     assert_nil Kind::Of::Array.or_nil({})
     assert_equal([1], Kind::Of::Array.or_nil([1]))
+
+    assert_kind_undefined Kind::Of::Array.or_undefined({})
+    assert_equal([2], Kind::Of::Array.or_undefined([2]))
+
+    # --
+
+    assert_same(Kind::Of::Array, Kind.of.Array)
+
+    Kind::Of::Array.stub(:instance, -> (obj, opt) { [obj, opt] }) do
+      assert_equal([[1], {}], Kind.of.Array[[1]])
+    end
   end
 
   # --- Range
 
   def test_if_a_value_is_a_kind_of_range
     range = 1..2
+
+    assert_raises_kind_error(given: 'nil', expected: 'Range') { Kind.of.Range.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Range') { Kind.of.Range.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1', expected: 'Range') { Kind.of.Range.instance(1) }
+    assert_equal(range, Kind.of.Range.instance(range))
+    assert_equal(range, Kind.of.Range.instance(nil, or: range))
+    assert_equal(range, Kind.of.Range.instance(3, or: range))
+    assert_equal(range, Kind.of.Range.instance(Kind::Undefined, or: range))
+    assert_raises_kind_error(given: 'nil', expected: 'Range') { Kind.of.Range.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Range') { Kind.of.Range.instance(Kind::Undefined, or: nil) }
 
     refute Kind.of.Range.instance?({})
     assert Kind.of.Range.instance?(range)
@@ -264,7 +588,20 @@ class Kind::OfCheckersTest < Minitest::Test
     assert_nil Kind.of.Range.or_nil({})
     assert_equal(range, Kind.of.Range.or_nil(range))
 
+    assert_kind_undefined Kind.of.Range.or_undefined({})
+    assert_equal(range, Kind.of.Range.or_undefined(range))
+
     # ---
+
+    assert_raises_kind_error(given: 'nil', expected: 'Range') { Kind::Of::Range.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Range') { Kind::Of::Range.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1', expected: 'Range') { Kind::Of::Range.instance(1) }
+    assert_equal(range, Kind::Of::Range.instance(range))
+    assert_equal(range, Kind::Of::Range.instance(nil, or: range))
+    assert_equal(range, Kind::Of::Range.instance(3, or: range))
+    assert_equal(range, Kind::Of::Range.instance(Kind::Undefined, or: range))
+    assert_raises_kind_error(given: 'nil', expected: 'Range') { Kind::Of::Range.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Range') { Kind::Of::Range.instance(Kind::Undefined, or: nil) }
 
     refute Kind::Of::Range.instance?({})
     assert Kind::Of::Range.instance?(range)
@@ -275,11 +612,32 @@ class Kind::OfCheckersTest < Minitest::Test
 
     assert_nil Kind::Of::Range.or_nil({})
     assert_equal(range, Kind::Of::Range.or_nil(range))
+
+    assert_kind_undefined Kind::Of::Range.or_undefined({})
+    assert_equal(range, Kind::Of::Range.or_undefined(range))
+
+    # --
+
+    assert_same(Kind::Of::Range, Kind.of.Range)
+
+    Kind::Of::Range.stub(:instance, -> (obj, opt) { [obj, opt] }) do
+      assert_equal([range, {}], Kind.of.Range[range])
+    end
   end
 
   # --- Hash
 
   def test_if_a_value_is_a_kind_of_hash
+    assert_raises_kind_error(given: 'nil', expected: 'Hash') { Kind.of.Hash.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Hash') { Kind.of.Hash.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1', expected: 'Hash') { Kind.of.Hash.instance(1) }
+    assert_equal({}, Kind.of.Hash.instance({}))
+    assert_equal({}, Kind.of.Hash.instance(nil, or: {}))
+    assert_equal({}, Kind.of.Hash.instance(3, or: {}))
+    assert_equal({}, Kind.of.Hash.instance(Kind::Undefined, or: {}))
+    assert_raises_kind_error(given: 'nil', expected: 'Hash') { Kind.of.Hash.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Hash') { Kind.of.Hash.instance(Kind::Undefined, or: nil) }
+
     refute Kind.of.Hash.instance?('')
     assert Kind.of.Hash.instance?({})
 
@@ -289,7 +647,20 @@ class Kind::OfCheckersTest < Minitest::Test
     assert_nil Kind.of.Hash.or_nil('')
     assert_equal({a: 1}, Kind.of.Hash.or_nil(a: 1))
 
+    assert_kind_undefined Kind.of.Hash.or_undefined([])
+    assert_equal({b: 2}, Kind.of.Hash.or_undefined({b: 2}))
+
     # ---
+
+    assert_raises_kind_error(given: 'nil', expected: 'Hash') { Kind::Of::Hash.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Hash') { Kind::Of::Hash.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1', expected: 'Hash') { Kind::Of::Hash.instance(1) }
+    assert_equal({}, Kind::Of::Hash.instance({}))
+    assert_equal({}, Kind::Of::Hash.instance(nil, or: {}))
+    assert_equal({}, Kind::Of::Hash.instance(3, or: {}))
+    assert_equal({}, Kind::Of::Hash.instance(Kind::Undefined, or: {}))
+    assert_raises_kind_error(given: 'nil', expected: 'Hash') { Kind::Of::Hash.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Hash') { Kind::Of::Hash.instance(Kind::Undefined, or: nil) }
 
     refute Kind::Of::Hash.instance?('')
     assert Kind::Of::Hash.instance?({})
@@ -300,6 +671,17 @@ class Kind::OfCheckersTest < Minitest::Test
 
     assert_nil Kind::Of::Hash.or_nil('')
     assert_equal({a: 1}, Kind::Of::Hash.or_nil(a: 1))
+
+    assert_kind_undefined Kind::Of::Hash.or_undefined([])
+    assert_equal({b: 2}, Kind::Of::Hash.or_undefined({b: 2}))
+
+    # --
+
+    assert_same(Kind::Of::Hash, Kind.of.Hash)
+
+    Kind::Of::Hash.stub(:instance, -> (obj, opt) { [obj, opt] }) do
+      assert_equal([{c: 3}, {}], Kind.of.Hash[{c: 3}])
+    end
   end
 
   # --- Struct
@@ -307,6 +689,16 @@ class Kind::OfCheckersTest < Minitest::Test
   def test_if_a_value_is_a_kind_of_struct
     struct = Struct.new(:name)
     person = struct.new('John Doe')
+
+    assert_raises_kind_error(given: 'nil', expected: 'Struct') { Kind.of.Struct.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Struct') { Kind.of.Struct.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1', expected: 'Struct') { Kind.of.Struct.instance(1) }
+    assert_equal(person, Kind.of.Struct.instance(person))
+    assert_equal(person, Kind.of.Struct.instance(nil, or: person))
+    assert_equal(person, Kind.of.Struct.instance(3, or: person))
+    assert_equal(person, Kind.of.Struct.instance(Kind::Undefined, or: person))
+    assert_raises_kind_error(given: 'nil', expected: 'Struct') { Kind.of.Struct.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Struct') { Kind.of.Struct.instance(Kind::Undefined, or: nil) }
 
     refute Kind.of.Struct.instance?({})
     assert Kind.of.Struct.instance?(person)
@@ -317,7 +709,20 @@ class Kind::OfCheckersTest < Minitest::Test
     assert_nil Kind.of.Struct.or_nil('')
     assert_equal(person, Kind.of.Struct.or_nil(person))
 
+    assert_kind_undefined Kind.of.Struct.or_undefined([])
+    assert_equal(person, Kind.of.Struct.or_undefined(person))
+
     # ---
+
+    assert_raises_kind_error(given: 'nil', expected: 'Struct') { Kind::Of::Struct.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Struct') { Kind::Of::Struct.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1', expected: 'Struct') { Kind::Of::Struct.instance(1) }
+    assert_equal(person, Kind::Of::Struct.instance(person))
+    assert_equal(person, Kind::Of::Struct.instance(nil, or: person))
+    assert_equal(person, Kind::Of::Struct.instance(3, or: person))
+    assert_equal(person, Kind::Of::Struct.instance(Kind::Undefined, or: person))
+    assert_raises_kind_error(given: 'nil', expected: 'Struct') { Kind::Of::Struct.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Struct') { Kind::Of::Struct.instance(Kind::Undefined, or: nil) }
 
     refute Kind::Of::Struct.instance?('')
     assert Kind::Of::Struct.instance?(person)
@@ -328,12 +733,33 @@ class Kind::OfCheckersTest < Minitest::Test
 
     assert_nil Kind::Of::Struct.or_nil('')
     assert_equal(person, Kind::Of::Struct.or_nil(person))
+
+    assert_kind_undefined Kind::Of::Struct.or_undefined([])
+    assert_equal(person, Kind::Of::Struct.or_undefined(person))
+
+    # --
+
+    assert_same(Kind::Of::Struct, Kind.of.Struct)
+
+    Kind::Of::Struct.stub(:instance, -> (obj, opt) { [obj, opt] }) do
+      assert_equal([person, {}], Kind.of.Struct[person])
+    end
   end
 
   # --- Enumerator
 
   def test_if_a_value_is_a_kind_of_enumerator
     enumerator = [].each
+
+    assert_raises_kind_error(given: 'nil', expected: 'Enumerator') { Kind.of.Enumerator.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Enumerator') { Kind.of.Enumerator.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1', expected: 'Enumerator') { Kind.of.Enumerator.instance(1) }
+    assert_equal(enumerator, Kind.of.Enumerator.instance(enumerator))
+    assert_equal(enumerator, Kind.of.Enumerator.instance(nil, or: enumerator))
+    assert_equal(enumerator, Kind.of.Enumerator.instance(3, or: enumerator))
+    assert_equal(enumerator, Kind.of.Enumerator.instance(Kind::Undefined, or: enumerator))
+    assert_raises_kind_error(given: 'nil', expected: 'Enumerator') { Kind.of.Enumerator.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Enumerator') { Kind.of.Enumerator.instance(Kind::Undefined, or: nil) }
 
     refute Kind.of.Enumerator.instance?({})
     assert Kind.of.Enumerator.instance?(enumerator)
@@ -344,7 +770,20 @@ class Kind::OfCheckersTest < Minitest::Test
     assert_nil Kind.of.Enumerator.or_nil('')
     assert_equal(enumerator, Kind.of.Enumerator.or_nil(enumerator))
 
+    assert_kind_undefined Kind.of.Enumerator.or_undefined([])
+    assert_equal(enumerator, Kind.of.Enumerator.or_undefined(enumerator))
+
     # ---
+
+    assert_raises_kind_error(given: 'nil', expected: 'Enumerator') { Kind::Of::Enumerator.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Enumerator') { Kind::Of::Enumerator.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1', expected: 'Enumerator') { Kind::Of::Enumerator.instance(1) }
+    assert_equal(enumerator, Kind::Of::Enumerator.instance(enumerator))
+    assert_equal(enumerator, Kind::Of::Enumerator.instance(nil, or: enumerator))
+    assert_equal(enumerator, Kind::Of::Enumerator.instance(3, or: enumerator))
+    assert_equal(enumerator, Kind::Of::Enumerator.instance(Kind::Undefined, or: enumerator))
+    assert_raises_kind_error(given: 'nil', expected: 'Enumerator') { Kind::Of::Enumerator.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Enumerator') { Kind::Of::Enumerator.instance(Kind::Undefined, or: nil) }
 
     refute Kind::Of::Enumerator.instance?('')
     assert Kind::Of::Enumerator.instance?(enumerator)
@@ -355,12 +794,93 @@ class Kind::OfCheckersTest < Minitest::Test
 
     assert_nil Kind::Of::Enumerator.or_nil('')
     assert_equal(enumerator, Kind::Of::Enumerator.or_nil(enumerator))
+
+    assert_kind_undefined Kind::Of::Enumerator.or_undefined([])
+    assert_equal(enumerator, Kind::Of::Enumerator.or_undefined(enumerator))
+
+    # --
+
+    assert_same(Kind::Of::Enumerator, Kind.of.Enumerator)
+
+    Kind::Of::Enumerator.stub(:instance, -> (obj, opt) { [obj, opt] }) do
+      assert_equal([enumerator, {}], Kind.of.Enumerator[enumerator])
+    end
+  end
+
+  # --- Set
+
+  def test_if_a_value_is_a_kind_of_set
+    set = Set.new
+
+    assert_raises_kind_error(given: 'nil', expected: 'Set') { Kind.of.Set.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Set') { Kind.of.Set.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '[]', expected: 'Set') { Kind.of.Set.instance([]) }
+    assert_equal(set, Kind.of.Set.instance(set))
+    assert_equal(set, Kind.of.Set.instance(nil, or: set))
+    assert_equal(set, Kind.of.Set.instance({}, or: set))
+    assert_equal(set, Kind.of.Set.instance(Kind::Undefined, or: set))
+    assert_raises_kind_error(given: 'nil', expected: 'Set') { Kind.of.Set.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Set') { Kind.of.Set.instance(Kind::Undefined, or: nil) }
+
+    refute Kind.of.Set.instance?({})
+    assert Kind.of.Set.instance?(set)
+
+    assert Kind.of.Set.class?(Set)
+    assert Kind.of.Set.class?(Class.new(Set))
+
+    assert_nil Kind.of.Set.or_nil('')
+    assert_equal(set, Kind.of.Set.or_nil(set))
+
+    assert_kind_undefined Kind.of.Set.or_undefined([])
+    assert_equal(set, Kind.of.Set.or_undefined(set))
+
+    # ---
+
+    assert_raises_kind_error(given: 'nil', expected: 'Set') { Kind::Of::Set.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Set') { Kind::Of::Set.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '[]', expected: 'Set') { Kind::Of::Set.instance([]) }
+    assert_equal(set, Kind::Of::Set.instance(set))
+    assert_equal(set, Kind::Of::Set.instance(nil, or: set))
+    assert_equal(set, Kind::Of::Set.instance({}, or: set))
+    assert_equal(set, Kind::Of::Set.instance(Kind::Undefined, or: set))
+    assert_raises_kind_error(given: 'nil', expected: 'Set') { Kind::Of::Set.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Set') { Kind::Of::Set.instance(Kind::Undefined, or: nil) }
+
+    refute Kind::Of::Set.instance?({})
+    assert Kind::Of::Set.instance?(set)
+
+    assert Kind::Of::Set.class?(Set)
+    assert Kind::Of::Set.class?(Class.new(Set))
+
+    assert_nil Kind::Of::Set.or_nil('')
+    assert_equal(set, Kind::Of::Set.or_nil(set))
+
+    assert_kind_undefined Kind::Of::Set.or_undefined([])
+    assert_equal(set, Kind::Of::Set.or_undefined(set))
+
+    # --
+
+    assert_same(Kind::Of::Set, Kind.of.Set)
+
+    Kind::Of::Set.stub(:instance, -> (obj, opt) { [obj, opt] }) do
+      assert_equal([set, {}], Kind.of.Set[set])
+    end
   end
 
   # --- Method
 
   def test_if_a_value_is_a_kind_of_method
     method = [1,2].method(:first)
+
+    assert_raises_kind_error(given: 'nil', expected: 'Method') { Kind.of.Method.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Method') { Kind.of.Method.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1', expected: 'Method') { Kind.of.Method.instance(1) }
+    assert_equal(method, Kind.of.Method.instance(method))
+    assert_equal(method, Kind.of.Method.instance(nil, or: method))
+    assert_equal(method, Kind.of.Method.instance(3, or: method))
+    assert_equal(method, Kind.of.Method.instance(Kind::Undefined, or: method))
+    assert_raises_kind_error(given: 'nil', expected: 'Method') { Kind.of.Method.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Method') { Kind.of.Method.instance(Kind::Undefined, or: nil) }
 
     refute Kind.of.Method.instance?({})
     assert Kind.of.Method.instance?(method)
@@ -371,7 +891,20 @@ class Kind::OfCheckersTest < Minitest::Test
     assert_nil Kind.of.Method.or_nil('')
     assert_equal(method, Kind.of.Method.or_nil(method))
 
+    assert_kind_undefined Kind.of.Method.or_undefined([])
+    assert_equal(method, Kind.of.Method.or_undefined(method))
+
     # ---
+
+    assert_raises_kind_error(given: 'nil', expected: 'Method') { Kind::Of::Method.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Method') { Kind::Of::Method.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1', expected: 'Method') { Kind::Of::Method.instance(1) }
+    assert_equal(method, Kind::Of::Method.instance(method))
+    assert_equal(method, Kind::Of::Method.instance(nil, or: method))
+    assert_equal(method, Kind::Of::Method.instance(3, or: method))
+    assert_equal(method, Kind::Of::Method.instance(Kind::Undefined, or: method))
+    assert_raises_kind_error(given: 'nil', expected: 'Method') { Kind::Of::Method.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Method') { Kind::Of::Method.instance(Kind::Undefined, or: nil) }
 
     refute Kind::Of::Method.instance?('')
     assert Kind::Of::Method.instance?(method)
@@ -382,6 +915,18 @@ class Kind::OfCheckersTest < Minitest::Test
 
     assert_nil Kind::Of::Method.or_nil('')
     assert_equal(method, Kind::Of::Method.or_nil(method))
+
+    assert_kind_undefined Kind::Of::Method.or_undefined([])
+    assert_equal(method, Kind::Of::Method.or_undefined(method))
+
+
+    # --
+
+    assert_same(Kind::Of::Method, Kind.of.Method)
+
+    Kind::Of::Method.stub(:instance, -> (obj, opt) { [obj, opt] }) do
+      assert_equal([method, {}], Kind.of.Method[method])
+    end
   end
 
   # --- Proc
@@ -389,6 +934,16 @@ class Kind::OfCheckersTest < Minitest::Test
   def test_if_a_value_is_a_kind_of_proc
     sum = proc { |a, b| a + b }
     sub = lambda { |a, b| a - b }
+
+    assert_raises_kind_error(given: 'nil', expected: 'Proc') { Kind.of.Proc.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Proc') { Kind.of.Proc.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1', expected: 'Proc') { Kind.of.Proc.instance(1) }
+    assert_equal(sum, Kind.of.Proc.instance(sum))
+    assert_equal(sum, Kind.of.Proc.instance(nil, or: sum))
+    assert_equal(sub, Kind.of.Proc.instance(3, or: sub))
+    assert_equal(sub, Kind.of.Proc.instance(Kind::Undefined, or: sub))
+    assert_raises_kind_error(given: 'nil', expected: 'Proc') { Kind.of.Proc.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Proc') { Kind.of.Proc.instance(Kind::Undefined, or: nil) }
 
     refute Kind.of.Proc.instance?({})
     assert Kind.of.Proc.instance?(sum)
@@ -401,7 +956,21 @@ class Kind::OfCheckersTest < Minitest::Test
     assert_equal(sum, Kind.of.Proc.or_nil(sum))
     assert_equal(sub, Kind.of.Proc.or_nil(sub))
 
+    assert_kind_undefined Kind.of.Proc.or_undefined([])
+    assert_equal(sum, Kind.of.Proc.or_undefined(sum))
+    assert_equal(sub, Kind.of.Proc.or_undefined(sub))
+
     # ---
+
+    assert_raises_kind_error(given: 'nil', expected: 'Proc') { Kind::Of::Proc.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Proc') { Kind::Of::Proc.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1', expected: 'Proc') { Kind::Of::Proc.instance(1) }
+    assert_equal(sum, Kind::Of::Proc.instance(sum))
+    assert_equal(sum, Kind::Of::Proc.instance(nil, or: sum))
+    assert_equal(sub, Kind::Of::Proc.instance(3, or: sub))
+    assert_equal(sub, Kind::Of::Proc.instance(Kind::Undefined, or: sub))
+    assert_raises_kind_error(given: 'nil', expected: 'Proc') { Kind::Of::Proc.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Proc') { Kind::Of::Proc.instance(Kind::Undefined, or: nil) }
 
     refute Kind::Of::Proc.instance?('')
     assert Kind::Of::Proc.instance?(sum)
@@ -414,12 +983,34 @@ class Kind::OfCheckersTest < Minitest::Test
     assert_nil Kind::Of::Proc.or_nil('')
     assert_equal(sum, Kind::Of::Proc.or_nil(sum))
     assert_equal(sub, Kind::Of::Proc.or_nil(sub))
+
+    assert_kind_undefined Kind::Of::Proc.or_undefined([])
+    assert_equal(sum, Kind::Of::Proc.or_undefined(sum))
+    assert_equal(sub, Kind::Of::Proc.or_undefined(sub))
+
+    # --
+
+    assert_same(Kind::Of::Proc, Kind.of.Proc)
+
+    Kind::Of::Proc.stub(:instance, -> (obj, opt) { [obj, opt] }) do
+      assert_equal([sum, {}], Kind.of.Proc[sum])
+    end
   end
 
   # --- IO
 
   def test_if_a_value_is_a_kind_of_io
     io = IO.new(1)
+
+    assert_raises_kind_error(given: 'nil', expected: 'IO') { Kind.of.IO.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'IO') { Kind.of.IO.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1', expected: 'IO') { Kind.of.IO.instance(1) }
+    assert_equal(io, Kind.of.IO.instance(io))
+    assert_equal(io, Kind.of.IO.instance(nil, or: io))
+    assert_equal(io, Kind.of.IO.instance(3, or: io))
+    assert_equal(io, Kind.of.IO.instance(Kind::Undefined, or: io))
+    assert_raises_kind_error(given: 'nil', expected: 'IO') { Kind.of.IO.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'IO') { Kind.of.IO.instance(Kind::Undefined, or: nil) }
 
     refute Kind.of.IO.instance?({})
     assert Kind.of.IO.instance?(io)
@@ -430,7 +1021,20 @@ class Kind::OfCheckersTest < Minitest::Test
     assert_nil Kind.of.IO.or_nil('')
     assert_equal(io, Kind.of.IO.or_nil(io))
 
+    assert_kind_undefined Kind.of.IO.or_undefined([])
+    assert_equal(io, Kind.of.IO.or_undefined(io))
+
     # ---
+
+    assert_raises_kind_error(given: 'nil', expected: 'IO') { Kind::Of::IO.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'IO') { Kind::Of::IO.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1', expected: 'IO') { Kind::Of::IO.instance(1) }
+    assert_equal(io, Kind::Of::IO.instance(io))
+    assert_equal(io, Kind::Of::IO.instance(nil, or: io))
+    assert_equal(io, Kind::Of::IO.instance(3, or: io))
+    assert_equal(io, Kind::Of::IO.instance(Kind::Undefined, or: io))
+    assert_raises_kind_error(given: 'nil', expected: 'IO') { Kind::Of::IO.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'IO') { Kind::Of::IO.instance(Kind::Undefined, or: nil) }
 
     refute Kind::Of::IO.instance?('')
     assert Kind::Of::IO.instance?(io)
@@ -441,6 +1045,17 @@ class Kind::OfCheckersTest < Minitest::Test
 
     assert_nil Kind::Of::IO.or_nil('')
     assert_equal(io, Kind::Of::IO.or_nil(io))
+
+    assert_kind_undefined Kind::Of::IO.or_undefined([])
+    assert_equal(io, Kind::Of::IO.or_undefined(io))
+
+    # --
+
+    assert_same(Kind::Of::IO, Kind.of.IO)
+
+    Kind::Of::IO.stub(:instance, -> (obj, opt) { [obj, opt] }) do
+      assert_equal([io, {}], Kind.of.IO[io])
+    end
   end
 
   # --- File
@@ -449,6 +1064,16 @@ class Kind::OfCheckersTest < Minitest::Test
     file = File.new('.foo', 'w')
 
     # --
+
+    assert_raises_kind_error(given: 'nil', expected: 'File') { Kind.of.File.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'File') { Kind.of.File.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1', expected: 'File') { Kind.of.File.instance(1) }
+    assert_equal(file, Kind.of.File.instance(file))
+    assert_equal(file, Kind.of.File.instance(nil, or: file))
+    assert_equal(file, Kind.of.File.instance(3, or: file))
+    assert_equal(file, Kind.of.File.instance(Kind::Undefined, or: file))
+    assert_raises_kind_error(given: 'nil', expected: 'File') { Kind.of.File.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'File') { Kind.of.File.instance(Kind::Undefined, or: nil) }
 
     refute Kind.of.File.instance?({})
     assert Kind.of.File.instance?(file)
@@ -459,7 +1084,20 @@ class Kind::OfCheckersTest < Minitest::Test
     assert_nil Kind.of.File.or_nil('')
     assert_equal(file, Kind.of.File.or_nil(file))
 
+    assert_kind_undefined Kind.of.File.or_undefined([])
+    assert_equal(file, Kind.of.File.or_undefined(file))
+
     # ---
+
+    assert_raises_kind_error(given: 'nil', expected: 'File') { Kind::Of::File.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'File') { Kind::Of::File.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1', expected: 'File') { Kind::Of::File.instance(1) }
+    assert_equal(file, Kind::Of::File.instance(file))
+    assert_equal(file, Kind::Of::File.instance(nil, or: file))
+    assert_equal(file, Kind::Of::File.instance(3, or: file))
+    assert_equal(file, Kind::Of::File.instance(Kind::Undefined, or: file))
+    assert_raises_kind_error(given: 'nil', expected: 'File') { Kind::Of::File.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'File') { Kind::Of::File.instance(Kind::Undefined, or: nil) }
 
     refute Kind::Of::File.instance?('')
     assert Kind::Of::File.instance?(file)
@@ -470,11 +1108,32 @@ class Kind::OfCheckersTest < Minitest::Test
 
     assert_nil Kind::Of::File.or_nil('')
     assert_equal(file, Kind::Of::File.or_nil(file))
+
+    assert_kind_undefined Kind::Of::File.or_undefined([])
+    assert_equal(file, Kind::Of::File.or_undefined(file))
+
+    # --
+
+    assert_same(Kind::Of::File, Kind.of.File)
+
+    Kind::Of::File.stub(:instance, -> (obj, opt) { [obj, opt] }) do
+      assert_equal([file, {}], Kind.of.File[file])
+    end
   end
 
   # --- Boolean
 
   def test_if_a_value_is_a_kind_of_boolean
+    assert_raises_kind_error(given: 'nil', expected: 'Boolean') { Kind.of.Boolean.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Boolean') { Kind.of.Boolean.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1', expected: 'Boolean') { Kind.of.Boolean.instance(1) }
+    assert_equal(true, Kind.of.Boolean.instance(true))
+    assert_equal(true, Kind.of.Boolean.instance(nil, or: true))
+    assert_equal(false, Kind.of.Boolean.instance(3, or: false))
+    assert_equal(false, Kind.of.Boolean.instance(Kind::Undefined, or: false))
+    assert_raises_kind_error(given: 'nil', expected: 'Boolean') { Kind.of.Boolean.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Boolean') { Kind.of.Boolean.instance(Kind::Undefined, or: nil) }
+
     refute Kind.of.Boolean.instance?({})
     assert Kind.of.Boolean.instance?(true)
     assert Kind.of.Boolean.instance?(false)
@@ -488,7 +1147,21 @@ class Kind::OfCheckersTest < Minitest::Test
     assert_equal(true, Kind.of.Boolean.or_nil(true))
     assert_equal(false, Kind.of.Boolean.or_nil(false))
 
+    assert_kind_undefined Kind.of.Boolean.or_undefined('')
+    assert_equal(true, Kind.of.Boolean.or_undefined(true))
+    assert_equal(false, Kind.of.Boolean.or_undefined(false))
+
     # ---
+
+    assert_raises_kind_error(given: 'nil', expected: 'Boolean') { Kind::Of::Boolean.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Boolean') { Kind::Of::Boolean.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1', expected: 'Boolean') { Kind::Of::Boolean.instance(1) }
+    assert_equal(true, Kind::Of::Boolean.instance(true))
+    assert_equal(true, Kind::Of::Boolean.instance(nil, or: true))
+    assert_equal(false, Kind::Of::Boolean.instance(3, or: false))
+    assert_equal(false, Kind::Of::Boolean.instance(Kind::Undefined, or: false))
+    assert_raises_kind_error(given: 'nil', expected: 'Boolean') { Kind::Of::Boolean.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Boolean') { Kind::Of::Boolean.instance(Kind::Undefined, or: nil) }
 
     refute Kind::Of::Boolean.instance?('')
     assert Kind::Of::Boolean.instance?(true)
@@ -502,6 +1175,18 @@ class Kind::OfCheckersTest < Minitest::Test
     assert_nil Kind::Of::Boolean.or_nil('')
     assert_equal(true, Kind::Of::Boolean.or_nil(true))
     assert_equal(false, Kind::Of::Boolean.or_nil(false))
+
+    assert_kind_undefined Kind::Of::Boolean.or_undefined('')
+    assert_equal(true, Kind::Of::Boolean.or_undefined(true))
+    assert_equal(false, Kind::Of::Boolean.or_undefined(false))
+
+    # --
+
+    assert_same(Kind::Of::Boolean, Kind.of.Boolean)
+
+    Kind::Of::Boolean.stub(:instance, -> (obj, opt) { [obj, opt] }) do
+      assert_equal([true, {}], Kind.of.Boolean[true])
+    end
   end
 
   # --- Lambda
@@ -511,6 +1196,16 @@ class Kind::OfCheckersTest < Minitest::Test
     sub = lambda { |a, b| a - b }
 
     # ---
+
+    assert_raises_kind_error(given: 'nil', expected: 'Lambda') { Kind::Of::Lambda.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Lambda') { Kind::Of::Lambda.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1', expected: 'Lambda') { Kind::Of::Lambda.instance(1) }
+    assert_equal(sub, Kind::Of::Lambda.instance(sub))
+    assert_equal(sub, Kind::Of::Lambda.instance(nil, or: sub))
+    assert_equal(sub, Kind::Of::Lambda.instance(sum, or: sub))
+    assert_equal(sub, Kind::Of::Lambda.instance(Kind::Undefined, or: sub))
+    assert_raises_kind_error(given: 'nil', expected: 'Lambda') { Kind::Of::Lambda.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Lambda') { Kind::Of::Lambda.instance(Kind::Undefined, or: nil) }
 
     refute Kind.of.Lambda.instance?({})
     refute Kind.of.Lambda.instance?(sum)
@@ -522,6 +1217,10 @@ class Kind::OfCheckersTest < Minitest::Test
     assert_nil Kind.of.Lambda.or_nil('')
     assert_nil Kind.of.Lambda.or_nil(sum)
     assert_equal(sub, Kind.of.Lambda.or_nil(sub))
+
+    assert_kind_undefined Kind.of.Lambda.or_undefined('')
+    assert_kind_undefined Kind.of.Lambda.or_undefined(sum)
+    assert_equal(sub, Kind.of.Lambda.or_undefined(sub))
 
     # ---
 
@@ -536,6 +1235,14 @@ class Kind::OfCheckersTest < Minitest::Test
     assert_nil Kind::Of::Lambda.or_nil('')
     assert_nil Kind::Of::Lambda.or_nil(sum)
     assert_equal(sub, Kind::Of::Lambda.or_nil(sub))
+
+    # --
+
+    assert_same(Kind::Of::Lambda, Kind.of.Lambda)
+
+    Kind::Of::Lambda.stub(:instance, -> (obj, opt) { [obj, opt] }) do
+      assert_equal([sub, {}], Kind.of.Lambda[sub])
+    end
   end
 
   # --- Callable
@@ -548,6 +1255,16 @@ class Kind::OfCheckersTest < Minitest::Test
     sub = lambda { |a, b| a - b }
 
     # ---
+
+    assert_raises_kind_error(given: 'nil', expected: 'Callable') { Kind.of.Callable.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Callable') { Kind.of.Callable.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1', expected: 'Callable') { Kind.of.Callable.instance(1) }
+    assert_equal(sub, Kind.of.Callable.instance(sub))
+    assert_equal(sum, Kind.of.Callable.instance(nil, or: sum))
+    assert_equal(klass, Kind.of.Callable.instance(instance, or: klass))
+    assert_equal(klass, Kind.of.Callable.instance(Kind::Undefined, or: klass))
+    assert_raises_kind_error(given: 'nil', expected: 'Callable') { Kind.of.Callable.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Callable') { Kind.of.Callable.instance(Kind::Undefined, or: nil) }
 
     refute Kind.of.Callable.instance?({})
     refute Kind.of.Callable.instance?(instance)
@@ -563,7 +1280,22 @@ class Kind::OfCheckersTest < Minitest::Test
     assert_equal(sub, Kind.of.Callable.or_nil(sub))
     assert_equal(klass, Kind.of.Callable.or_nil(klass))
 
+    assert_kind_undefined Kind.of.Callable.or_undefined('')
+    assert_kind_undefined Kind.of.Callable.or_undefined(instance)
+    assert_equal(sub, Kind.of.Callable.or_undefined(sub))
+    assert_equal(klass, Kind.of.Callable.or_undefined(klass))
+
     # ---
+
+    assert_raises_kind_error(given: 'nil', expected: 'Callable') { Kind::Of::Callable.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Callable') { Kind::Of::Callable.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1', expected: 'Callable') { Kind::Of::Callable.instance(1) }
+    assert_equal(sub, Kind::Of::Callable.instance(sub))
+    assert_equal(sum, Kind::Of::Callable.instance(nil, or: sum))
+    assert_equal(klass, Kind::Of::Callable.instance(instance, or: klass))
+    assert_equal(klass, Kind::Of::Callable.instance(Kind::Undefined, or: klass))
+    assert_raises_kind_error(given: 'nil', expected: 'Callable') { Kind::Of::Callable.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Callable') { Kind::Of::Callable.instance(Kind::Undefined, or: nil) }
 
     refute Kind::Of::Callable.instance?({})
     refute Kind::Of::Callable.instance?(instance)
@@ -578,6 +1310,19 @@ class Kind::OfCheckersTest < Minitest::Test
     assert_nil Kind::Of::Callable.or_nil(instance)
     assert_equal(sub, Kind::Of::Callable.or_nil(sub))
     assert_equal(klass, Kind::Of::Callable.or_nil(klass))
+
+    assert_kind_undefined Kind::Of::Callable.or_undefined('')
+    assert_kind_undefined Kind::Of::Callable.or_undefined(instance)
+    assert_equal(sub, Kind::Of::Callable.or_undefined(sub))
+    assert_equal(klass, Kind::Of::Callable.or_undefined(klass))
+
+    # --
+
+    assert_same(Kind::Of::Callable, Kind.of.Callable)
+
+    Kind::Of::Callable.stub(:instance, -> (obj, opt) { [obj, opt] }) do
+      assert_equal([klass, {}], Kind.of.Callable[klass])
+    end
   end
   # --- Queue
 
@@ -585,6 +1330,16 @@ class Kind::OfCheckersTest < Minitest::Test
     queue = Queue.new
 
     # ---
+
+    assert_raises_kind_error(given: 'nil', expected: 'Thread::Queue') { Kind.of.Queue.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Thread::Queue') { Kind.of.Queue.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1', expected: 'Thread::Queue') { Kind.of.Queue.instance(1) }
+    assert_equal(queue, Kind.of.Queue.instance(queue))
+    assert_equal(queue, Kind.of.Queue.instance(nil, or: queue))
+    assert_equal(queue, Kind.of.Queue.instance([], or: queue))
+    assert_equal(queue, Kind.of.Queue.instance(Kind::Undefined, or: queue))
+    assert_raises_kind_error(given: 'nil', expected: 'Thread::Queue') { Kind.of.Queue.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Thread::Queue') { Kind.of.Queue.instance(Kind::Undefined, or: nil) }
 
     refute Kind.of.Queue.instance?({})
     assert Kind.of.Queue.instance?(queue)
@@ -595,7 +1350,20 @@ class Kind::OfCheckersTest < Minitest::Test
     assert_nil Kind.of.Queue.or_nil('')
     assert_equal(queue, Kind.of.Queue.or_nil(queue))
 
+    assert_kind_undefined Kind.of.Queue.or_undefined('')
+    assert_equal(queue, Kind.of.Queue.or_undefined(queue))
+
     # ---
+
+    assert_raises_kind_error(given: 'nil', expected: 'Thread::Queue') { Kind::Of::Queue.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Thread::Queue') { Kind::Of::Queue.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1', expected: 'Thread::Queue') { Kind::Of::Queue.instance(1) }
+    assert_equal(queue, Kind::Of::Queue.instance(queue))
+    assert_equal(queue, Kind::Of::Queue.instance(nil, or: queue))
+    assert_equal(queue, Kind::Of::Queue.instance([], or: queue))
+    assert_equal(queue, Kind::Of::Queue.instance(Kind::Undefined, or: queue))
+    assert_raises_kind_error(given: 'nil', expected: 'Thread::Queue') { Kind::Of::Queue.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Thread::Queue') { Kind::Of::Queue.instance(Kind::Undefined, or: nil) }
 
     refute Kind::Of::Queue.instance?('')
     assert Kind::Of::Queue.instance?(queue)
@@ -606,11 +1374,103 @@ class Kind::OfCheckersTest < Minitest::Test
 
     assert_nil Kind::Of::Queue.or_nil('')
     assert_equal(queue, Kind::Of::Queue.or_nil(queue))
+
+    assert_kind_undefined Kind::Of::Queue.or_undefined('')
+    assert_equal(queue, Kind::Of::Queue.or_undefined(queue))
+
+    # --
+
+    assert_same(Kind::Of::Queue, Kind.of.Queue)
+
+    Kind::Of::Queue.stub(:instance, -> (obj, opt) { [obj, opt] }) do
+      assert_equal([queue, {}], Kind.of.Queue[queue])
+    end
+  end
+
+  # -- Class: Kind::Maybe
+
+  def test_if_the_object_is_a_kind_of_maybe
+    some = Kind::Maybe[1]
+    none = Kind::Maybe[none]
+
+    # ---
+
+    assert_raises_kind_error(given: 'nil', expected: 'Kind::Maybe::Result') { Kind.of.Maybe.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Kind::Maybe::Result') { Kind.of.Maybe.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1', expected: 'Kind::Maybe::Result') { Kind.of.Maybe.instance(1) }
+    assert_equal(some, Kind.of.Maybe.instance(some))
+    assert_equal(some, Kind.of.Maybe.instance(nil, or: some))
+    assert_equal(none, Kind.of.Maybe.instance([], or: none))
+    assert_equal(none, Kind.of.Maybe.instance(Kind::Undefined, or: none))
+    assert_raises_kind_error(given: 'nil', expected: 'Kind::Maybe::Result') { Kind.of.Maybe.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Kind::Maybe::Result') { Kind.of.Maybe.instance(Kind::Undefined, or: nil) }
+
+    refute Kind.of.Maybe.instance?({})
+    assert Kind.of.Maybe.instance?(some)
+    assert Kind.of.Maybe.instance?(none)
+
+    assert Kind.of.Maybe.class?(Kind::Maybe::Result)
+    assert Kind.of.Maybe.class?(Kind::Maybe::Some)
+    assert Kind.of.Maybe.class?(Kind::Maybe::None)
+
+    assert_nil Kind.of.Maybe.or_nil('')
+    assert_equal(some, Kind.of.Maybe.or_nil(some))
+    assert_equal(none, Kind.of.Maybe.or_nil(none))
+
+    assert_kind_undefined Kind.of.Maybe.or_undefined('')
+    assert_equal(some, Kind.of.Maybe.or_undefined(some))
+    assert_equal(none, Kind.of.Maybe.or_undefined(none))
+
+    # ---
+
+    assert_raises_kind_error(given: 'nil', expected: 'Kind::Maybe::Result') { Kind::Of::Maybe.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Kind::Maybe::Result') { Kind::Of::Maybe.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1', expected: 'Kind::Maybe::Result') { Kind::Of::Maybe.instance(1) }
+    assert_equal(none, Kind::Of::Maybe.instance(none))
+    assert_equal(none, Kind::Of::Maybe.instance(nil, or: none))
+    assert_equal(some, Kind::Of::Maybe.instance([], or: some))
+    assert_equal(some, Kind::Of::Maybe.instance(Kind::Undefined, or: some))
+    assert_raises_kind_error(given: 'nil', expected: 'Kind::Maybe::Result') { Kind::Of::Maybe.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Kind::Maybe::Result') { Kind::Of::Maybe.instance(Kind::Undefined, or: nil) }
+
+    refute Kind::Of::Maybe.instance?({})
+    assert Kind::Of::Maybe.instance?(some)
+    assert Kind::Of::Maybe.instance?(none)
+
+    assert Kind::Of::Maybe.class?(Kind::Maybe::Result)
+    assert Kind::Of::Maybe.class?(Kind::Maybe::Some)
+    assert Kind::Of::Maybe.class?(Kind::Maybe::None)
+
+    assert_nil Kind::Of::Maybe.or_nil('')
+    assert_equal(some, Kind::Of::Maybe.or_nil(some))
+    assert_equal(none, Kind::Of::Maybe.or_nil(none))
+
+    assert_kind_undefined Kind::Of::Maybe.or_undefined('')
+    assert_equal(some, Kind::Of::Maybe.or_undefined(some))
+    assert_equal(none, Kind::Of::Maybe.or_undefined(none))
+
+    # --
+
+    assert_same(Kind::Of::Maybe, Kind.of.Maybe)
+
+    Kind::Of::Maybe.stub(:instance, -> (obj, opt) { [obj, opt] }) do
+      assert_equal([some, {}], Kind.of.Maybe[some])
+    end
   end
 
   # -- Modules
 
   def test_if_a_value_is_a_kind_of_module
+    assert_raises_kind_error(given: 'nil', expected: 'Module') { Kind.of.Module.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Module') { Kind.of.Module.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: 'Symbol', expected: 'Module') { Kind.of.Module.instance(Symbol) }
+    assert_equal(Enumerable, Kind.of.Module.instance(Enumerable))
+    assert_equal(Enumerable, Kind.of.Module.instance(nil, or: Enumerable))
+    assert_equal(Comparable, Kind.of.Module.instance(String, or: Comparable))
+    assert_equal(Comparable, Kind.of.Module.instance(Kind::Undefined, or: Comparable))
+    assert_raises_kind_error(given: 'nil', expected: 'Module') { Kind.of.Module.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Module') { Kind.of.Module.instance(Kind::Undefined, or: nil) }
+
     refute Kind.of.Module.instance?([1])
     assert Kind.of.Module.instance?(Enumerable)
 
@@ -620,7 +1480,20 @@ class Kind::OfCheckersTest < Minitest::Test
     assert_nil Kind.of.Module.or_nil('')
     assert_equal(Enumerable, Kind.of.Module.or_nil(Enumerable))
 
+    assert_kind_undefined Kind.of.Module.or_undefined('')
+    assert_equal(Comparable, Kind.of.Module.or_undefined(Comparable))
+
     # ---
+
+    assert_raises_kind_error(given: 'nil', expected: 'Module') { Kind::Of::Module.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Module') { Kind::Of::Module.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1', expected: 'Module') { Kind::Of::Module.instance(1) }
+    assert_equal(Enumerable, Kind::Of::Module.instance(Enumerable))
+    assert_equal(Enumerable, Kind::Of::Module.instance(nil, or: Enumerable))
+    assert_equal(Comparable, Kind::Of::Module.instance([], or: Comparable))
+    assert_equal(Comparable, Kind::Of::Module.instance(Kind::Undefined, or: Comparable))
+    assert_raises_kind_error(given: 'nil', expected: 'Module') { Kind::Of::Module.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Module') { Kind::Of::Module.instance(Kind::Undefined, or: nil) }
 
     refute Kind::Of::Module.instance?([1])
     assert Kind::Of::Module.instance?(Enumerable)
@@ -630,12 +1503,33 @@ class Kind::OfCheckersTest < Minitest::Test
 
     assert_nil Kind::Of::Module.or_nil('')
     assert_equal(Enumerable, Kind::Of::Module.or_nil(Enumerable))
+
+    assert_kind_undefined Kind::Of::Module.or_undefined('')
+    assert_equal(Comparable, Kind::Of::Module.or_undefined(Comparable))
+
+    # --
+
+    assert_same(Kind::Of::Module, Kind.of.Module)
+
+    Kind::Of::Module.stub(:instance, -> (obj, opt) { [obj, opt] }) do
+      assert_equal([Comparable, {}], Kind.of.Module[Comparable])
+    end
   end
 
   # --- Enumerable
 
   def test_if_a_value_is_a_kind_of_enumerable
     value = [1]
+
+    assert_raises_kind_error(given: 'nil', expected: 'Enumerable') { Kind.of.Enumerable.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Enumerable') { Kind.of.Enumerable.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1', expected: 'Enumerable') { Kind.of.Enumerable.instance(1) }
+    assert_equal(value, Kind.of.Enumerable.instance(value))
+    assert_equal(value, Kind.of.Enumerable.instance(nil, or: value))
+    assert_equal(value, Kind.of.Enumerable.instance(1, or: value))
+    assert_equal(value, Kind.of.Enumerable.instance(Kind::Undefined, or: value))
+    assert_raises_kind_error(given: 'nil', expected: 'Enumerable') { Kind.of.Enumerable.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Enumerable') { Kind.of.Enumerable.instance(Kind::Undefined, or: nil) }
 
     refute Kind.of.Enumerable.instance?(1)
     assert Kind.of.Enumerable.instance?(value)
@@ -646,7 +1540,20 @@ class Kind::OfCheckersTest < Minitest::Test
     assert_nil Kind.of.Enumerable.or_nil('')
     assert_equal(value, Kind.of.Enumerable.or_nil(value))
 
+    assert_kind_undefined Kind.of.Enumerable.or_undefined('')
+    assert_equal(value, Kind.of.Enumerable.or_undefined(value))
+
     # ---
+
+    assert_raises_kind_error(given: 'nil', expected: 'Enumerable') { Kind::Of::Enumerable.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Enumerable') { Kind::Of::Enumerable.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '1', expected: 'Enumerable') { Kind::Of::Enumerable.instance(1) }
+    assert_equal(value, Kind::Of::Enumerable.instance(value))
+    assert_equal(value, Kind::Of::Enumerable.instance(nil, or: value))
+    assert_equal(value, Kind::Of::Enumerable.instance(1, or: value))
+    assert_equal(value, Kind::Of::Enumerable.instance(Kind::Undefined, or: value))
+    assert_raises_kind_error(given: 'nil', expected: 'Enumerable') { Kind::Of::Enumerable.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Enumerable') { Kind::Of::Enumerable.instance(Kind::Undefined, or: nil) }
 
     refute Kind::Of::Enumerable.instance?('')
     assert Kind::Of::Enumerable.instance?(value)
@@ -657,12 +1564,33 @@ class Kind::OfCheckersTest < Minitest::Test
 
     assert_nil Kind::Of::Enumerable.or_nil('')
     assert_equal(value, Kind::Of::Enumerable.or_nil(value))
+
+    assert_kind_undefined Kind::Of::Enumerable.or_undefined('')
+    assert_equal(value, Kind::Of::Enumerable.or_undefined(value))
+
+    # --
+
+    assert_same(Kind::Of::Enumerable, Kind.of.Enumerable)
+
+    Kind::Of::Enumerable.stub(:instance, -> (obj, opt) { [obj, opt] }) do
+      assert_equal([value, {}], Kind.of.Enumerable[value])
+    end
   end
 
   # --- Comparable
 
   def test_if_a_value_is_a_kind_of_Comparable
     value = 1
+
+    assert_raises_kind_error(given: 'nil', expected: 'Comparable') { Kind.of.Comparable.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Comparable') { Kind.of.Comparable.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '[]', expected: 'Comparable') { Kind.of.Comparable.instance([]) }
+    assert_equal(value, Kind.of.Comparable.instance(value))
+    assert_equal(value, Kind.of.Comparable.instance(nil, or: value))
+    assert_equal(value, Kind.of.Comparable.instance(1, or: value))
+    assert_equal(value, Kind.of.Comparable.instance(Kind::Undefined, or: value))
+    assert_raises_kind_error(given: 'nil', expected: 'Comparable') { Kind.of.Comparable.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Comparable') { Kind.of.Comparable.instance(Kind::Undefined, or: nil) }
 
     refute Kind.of.Comparable.instance?([])
     assert Kind.of.Comparable.instance?(value)
@@ -673,7 +1601,20 @@ class Kind::OfCheckersTest < Minitest::Test
     assert_nil Kind.of.Comparable.or_nil([])
     assert_equal(value, Kind.of.Comparable.or_nil(value))
 
+    assert_kind_undefined Kind.of.Comparable.or_undefined([])
+    assert_equal(value, Kind.of.Comparable.or_undefined(value))
+
     # ---
+
+    assert_raises_kind_error(given: 'nil', expected: 'Comparable') { Kind::Of::Comparable.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Comparable') { Kind::Of::Comparable.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: '[]', expected: 'Comparable') { Kind::Of::Comparable.instance([]) }
+    assert_equal(value, Kind::Of::Comparable.instance(value))
+    assert_equal(value, Kind::Of::Comparable.instance(nil, or: value))
+    assert_equal(value, Kind::Of::Comparable.instance(1, or: value))
+    assert_equal(value, Kind::Of::Comparable.instance(Kind::Undefined, or: value))
+    assert_raises_kind_error(given: 'nil', expected: 'Comparable') { Kind::Of::Comparable.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Comparable') { Kind::Of::Comparable.instance(Kind::Undefined, or: nil) }
 
     refute Kind::Of::Comparable.instance?([])
     assert Kind::Of::Comparable.instance?(value)
@@ -684,5 +1625,16 @@ class Kind::OfCheckersTest < Minitest::Test
 
     assert_nil Kind::Of::Comparable.or_nil([])
     assert_equal(value, Kind::Of::Comparable.or_nil(value))
+
+    assert_kind_undefined Kind::Of::Comparable.or_undefined([])
+    assert_equal(value, Kind::Of::Comparable.or_undefined(value))
+
+    # --
+
+    assert_same(Kind::Of::Comparable, Kind.of.Comparable)
+
+    Kind::Of::Comparable.stub(:instance, -> (obj, opt) { [obj, opt] }) do
+      assert_equal([value, {}], Kind.of.Comparable[value])
+    end
   end
 end

--- a/test/kind/of_custom_type_with_namespace_test.rb
+++ b/test/kind/of_custom_type_with_namespace_test.rb
@@ -63,6 +63,16 @@ class Kind::OfCustomTypeWithNamespaceTest < Minitest::Test
 
     # ---
 
+    assert_raises_kind_error(given: 'nil', expected: 'Account::User') { Kind.of.Account::User.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Account::User') { Kind.of.Account::User.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: ':a', expected: 'Account::User') { Kind.of.Account::User.instance(:a) }
+    assert_equal(user, Kind.of.Account::User.instance(user))
+    assert_equal(user, Kind.of.Account::User.instance(:a, or: user))
+    assert_equal(user, Kind.of.Account::User.instance(nil, or: user))
+    assert_equal(user, Kind.of.Account::User.instance(Kind::Undefined, or: user))
+    assert_raises_kind_error(given: 'nil', expected: 'Account::User') { Kind.of.Account::User.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Account::User') { Kind.of.Account::User.instance(Kind::Undefined, or: nil) }
+
     refute Kind.of.Account::User.instance?({})
     assert Kind.of.Account::User.instance?(user)
 
@@ -73,7 +83,28 @@ class Kind::OfCustomTypeWithNamespaceTest < Minitest::Test
     assert_nil Kind.of.Account::User.or_nil({})
     assert_equal(user, Kind.of.Account::User.or_nil(user))
 
+    assert_kind_undefined Kind.of.Account::User.or_undefined({})
+    assert_equal(user, Kind.of.Account::User.or_undefined(user))
+
     # -
+
+    assert_same(Kind::Of::Account::User, Kind.of.Account::User)
+
+    Kind::Of::Account::User.stub(:instance, -> (obj, opt) { [obj, opt] }) do
+      assert_equal([user, {}], Kind.of.Account::User[user])
+    end
+
+    # ---
+
+    assert_raises_kind_error(given: 'nil', expected: 'Account::User::Membership') { Kind.of.Account::User::Membership.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Account::User::Membership') { Kind.of.Account::User::Membership.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: ':a', expected: 'Account::User::Membership') { Kind.of.Account::User::Membership.instance(:a) }
+    assert_equal(membership, Kind.of.Account::User::Membership.instance(membership))
+    assert_equal(membership, Kind.of.Account::User::Membership.instance(:a, or: membership))
+    assert_equal(membership, Kind.of.Account::User::Membership.instance(nil, or: membership))
+    assert_equal(membership, Kind.of.Account::User::Membership.instance(Kind::Undefined, or: membership))
+    assert_raises_kind_error(given: 'nil', expected: 'Account::User::Membership') { Kind.of.Account::User::Membership.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Account::User::Membership') { Kind.of.Account::User::Membership.instance(Kind::Undefined, or: nil) }
 
     refute Kind.of.Account::User::Membership.instance?({})
     assert Kind.of.Account::User::Membership.instance?(membership)
@@ -84,6 +115,17 @@ class Kind::OfCustomTypeWithNamespaceTest < Minitest::Test
 
     assert_nil Kind.of.Account::User::Membership.or_nil({})
     assert_equal(membership, Kind.of.Account::User::Membership.or_nil(membership))
+
+    assert_kind_undefined Kind.of.Account::User::Membership.or_undefined({})
+    assert_equal(membership, Kind.of.Account::User::Membership.or_undefined(membership))
+
+    # -
+
+    assert_same(Kind::Of::Account::User::Membership, Kind.of.Account::User::Membership)
+
+    Kind::Of::Account::User::Membership.stub(:instance, -> (obj, opt) { [obj, opt] }) do
+      assert_equal([membership, {}], Kind.of.Account::User::Membership[membership])
+    end
 
     # ---
 

--- a/test/kind/of_test.rb
+++ b/test/kind/of_test.rb
@@ -1,0 +1,114 @@
+require 'test_helper'
+
+class Bar
+end
+
+module Foo
+  class Bar
+  end
+end
+
+class Kind::OfTest < Minitest::Test
+  def setup
+    @bar = Bar.new
+    @foo_bar = Foo::Bar.new
+  end
+
+  def test_the_method_call
+    assert_same(1, Kind::Of.call(Numeric, 1))
+    assert_same(@bar, Kind::Of.call(Bar, @bar))
+    assert_same(@foo_bar, Kind::Of.call(Foo::Bar, @foo_bar))
+
+    assert_raises_kind_error(given: '"1"', expected: 'Numeric') { Kind::Of.call(Numeric, '1') }
+    assert_raises_kind_error(given: '"1"', expected: 'Bar') { Kind::Of.call(Bar, '1') }
+    assert_raises_kind_error(given: '"1"', expected: 'Foo::Bar') { Kind::Of.call(Foo::Bar, '1') }
+  end
+
+  def test_the_kind_is_method
+    assert_same(Kind::Of, Kind.of)
+
+    # ---
+
+    assert_same(1, Kind.of(Numeric, 1))
+    assert_same(@bar, Kind.of(Bar, @bar))
+    assert_same(@foo_bar, Kind.of(Foo::Bar, @foo_bar))
+
+    assert_raises_kind_error(given: '"1"', expected: 'Numeric') { Kind.of(Numeric, '1') }
+    assert_raises_kind_error(given: '"1"', expected: 'Bar') { Kind.of(Bar, '1') }
+    assert_raises_kind_error(given: '"1"', expected: 'Foo::Bar') { Kind.of(Foo::Bar, '1') }
+
+    # ---
+
+    kind_of_bar = Kind.of(Bar)
+
+    assert_raises_kind_error(given: 'nil', expected: 'Bar') { kind_of_bar.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Bar') { kind_of_bar.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: ':a', expected: 'Bar') { kind_of_bar.instance(:a) }
+    assert_equal(@bar, kind_of_bar.instance(@bar))
+    assert_equal(@bar, kind_of_bar.instance(:a, or: @bar))
+    assert_equal(@bar, kind_of_bar.instance(nil, or: @bar))
+    assert_equal(@bar, kind_of_bar.instance(Kind::Undefined, or: @bar))
+    assert_raises_kind_error(given: 'nil', expected: 'Bar') { kind_of_bar.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Bar') { kind_of_bar.instance(Kind::Undefined, or: nil) }
+
+    refute kind_of_bar.instance?({})
+    assert kind_of_bar.instance?(@bar)
+
+    assert_equal(false, kind_of_bar.class?(Hash))
+    assert_equal(true, kind_of_bar.class?(Bar))
+    assert_equal(true, kind_of_bar.class?(Class.new(Bar)))
+
+    assert_nil kind_of_bar.or_nil({})
+    assert_equal(@bar, kind_of_bar.or_nil(@bar))
+
+    assert_kind_undefined kind_of_bar.or_undefined({})
+    assert_equal(@bar, kind_of_bar.or_undefined(@bar))
+
+    assert_same(kind_of_bar, Kind.of(Bar))
+
+    assert_instance_of(Kind::Checker, kind_of_bar)
+
+    kind_of_bar.stub(:instance, -> (obj, opt) { [obj, opt] }) do
+      assert_equal([@bar, {}], kind_of_bar[@bar])
+    end
+
+    # ---
+
+    kind_of_foo_bar = Kind.of(Foo::Bar)
+
+    assert_raises_kind_error(given: 'nil', expected: 'Foo::Bar') { kind_of_foo_bar.instance(nil) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Foo::Bar') { kind_of_foo_bar.instance(Kind::Undefined) }
+    assert_raises_kind_error(given: ':a', expected: 'Foo::Bar') { kind_of_foo_bar.instance(:a) }
+    assert_equal(@foo_bar, kind_of_foo_bar.instance(@foo_bar))
+    assert_equal(@foo_bar, kind_of_foo_bar.instance(:a, or: @foo_bar))
+    assert_equal(@foo_bar, kind_of_foo_bar.instance(nil, or: @foo_bar))
+    assert_equal(@foo_bar, kind_of_foo_bar.instance(Kind::Undefined, or: @foo_bar))
+    assert_raises_kind_error(given: 'nil', expected: 'Foo::Bar') { kind_of_foo_bar.instance(nil, or: Kind::Undefined) }
+    assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Foo::Bar') { kind_of_foo_bar.instance(Kind::Undefined, or: nil) }
+
+    refute kind_of_foo_bar.instance?({})
+    assert kind_of_foo_bar.instance?(@foo_bar)
+
+    assert_equal(false, kind_of_foo_bar.class?(Hash))
+    assert_equal(true, kind_of_foo_bar.class?(Foo::Bar))
+    assert_equal(true, kind_of_foo_bar.class?(Class.new(Foo::Bar)))
+
+    assert_nil kind_of_foo_bar.or_nil({})
+    assert_equal(@foo_bar, kind_of_foo_bar.or_nil(@foo_bar))
+
+    assert_kind_undefined kind_of_foo_bar.or_undefined({})
+    assert_equal(@foo_bar, kind_of_foo_bar.or_undefined(@foo_bar))
+
+    assert_same(kind_of_foo_bar, Kind.of(Foo::Bar))
+
+    assert_instance_of(Kind::Checker, kind_of_foo_bar)
+
+    kind_of_foo_bar.stub(:instance, -> (obj, opt) { [obj, opt] }) do
+      assert_equal([@foo_bar, {}], kind_of_foo_bar[@foo_bar])
+    end
+
+    # ---
+
+    assert_same(Kind::Of::String, Kind.of(String))
+  end
+end

--- a/test/kind/of_type_checkers_test.rb
+++ b/test/kind/of_type_checkers_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class Kind::OfBuiltInTypesTest < Minitest::Test
+class Kind::OfTypeCheckersTest < Minitest::Test
   # -- Class: String
 
   def test_if_the_object_is_a_kind_of_string
@@ -234,6 +234,25 @@ class Kind::OfBuiltInTypesTest < Minitest::Test
     assert_raises_kind_error('"default" expected to be a kind of Enumerator') { Kind.of.Enumerator(nil, or: 'default') }
   end
 
+  # -- Class: Set
+
+  def test_if_the_object_is_a_kind_of_set
+    assert_raises_kind_error('[] expected to be a kind of Set') { Kind.of.Set([]) }
+    assert_raises_kind_error('nil expected to be a kind of Set') { Kind.of.Set(nil) }
+
+    # ---
+
+    object = Set.new
+
+    assert_same(object, Kind.of.Set(object))
+
+    assert_equal(object, Kind.of.Set(nil, or: object))
+
+    # ---
+
+    assert_raises_kind_error('"default" expected to be a kind of Set') { Kind.of.Set(nil, or: 'default') }
+  end
+
   # -- Class: Method
 
   def test_if_the_object_is_a_kind_of_method
@@ -361,8 +380,8 @@ class Kind::OfBuiltInTypesTest < Minitest::Test
   # -- Class: Queue
 
   def test_if_the_object_is_a_kind_of_queue
-    assert_raises_kind_error('[] expected to be a kind of Queue') { Kind.of.Queue([]) }
-    assert_raises_kind_error('nil expected to be a kind of Queue') { Kind.of.Queue(nil) }
+    assert_raises_kind_error('[] expected to be a kind of Thread::Queue') { Kind.of.Queue([]) }
+    assert_raises_kind_error('nil expected to be a kind of Thread::Queue') { Kind.of.Queue(nil) }
 
     # ---
 
@@ -374,7 +393,49 @@ class Kind::OfBuiltInTypesTest < Minitest::Test
 
     # ---
 
-    assert_raises_kind_error('"default" expected to be a kind of Queue') { Kind.of.Queue(nil, or: 'default') }
+    assert_raises_kind_error('"default" expected to be a kind of Thread::Queue') { Kind.of.Queue(nil, or: 'default') }
+  end
+
+  # -- Class: Kind::Maybe
+
+  def test_if_the_object_is_a_kind_of_maybe
+    assert_raises_kind_error('[] expected to be a kind of Kind::Maybe::Result') { Kind.of.Maybe([]) }
+    assert_raises_kind_error('nil expected to be a kind of Kind::Maybe::Result') { Kind.of.Maybe(nil) }
+
+    # ---
+
+    some = Kind::Maybe[1]
+    none = Kind::Maybe[nil]
+
+    assert_same(some, Kind.of.Maybe(some))
+    assert_equal(some, Kind.of.Maybe(nil, or: some))
+
+    assert_same(none, Kind.of.Maybe(none))
+    assert_equal(none, Kind.of.Maybe(nil, or: none))
+
+    # ---
+
+    assert_raises_kind_error('"default" expected to be a kind of Kind::Maybe::Result') { Kind.of.Maybe(nil, or: 'default') }
+  end
+
+  def test_if_the_object_is_a_kind_of_optional
+    assert_raises_kind_error('[] expected to be a kind of Kind::Maybe::Result') { Kind.of.Optional([]) }
+    assert_raises_kind_error('nil expected to be a kind of Kind::Maybe::Result') { Kind.of.Optional(nil) }
+
+    # ---
+
+    some = Kind::Optional[1]
+    none = Kind::Optional[nil]
+
+    assert_same(some, Kind.of.Optional(some))
+    assert_equal(some, Kind.of.Optional(nil, or: some))
+
+    assert_same(none, Kind.of.Optional(none))
+    assert_equal(none, Kind.of.Optional(nil, or: none))
+
+    # ---
+
+    assert_raises_kind_error('"default" expected to be a kind of Kind::Maybe::Result') { Kind.of.Optional(nil, or: 'default') }
   end
 
   # -- Module: Enumerable

--- a/test/kind/undefined_test.rb
+++ b/test/kind/undefined_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Kind::UndefinedTest < Minitest::Test
   def test_inspect
-    assert_equal('Undefined', Kind::Undefined.inspect)
+    assert_equal('Kind::Undefined', Kind::Undefined.inspect)
   end
 
   def test_to_s

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,7 +19,18 @@ class Minitest::Test
     raise "Expected to raise #{exception} w/ message #{msg}, none raised"
   end
 
-  def assert_raises_kind_error(message, &block)
-    assert_raises_with_message(Kind::Error, message, &block)
+  def assert_raises_kind_error(arg, &block)
+    msg =
+      case arg
+      when String, Regexp then arg
+      when Hash then "#{arg.fetch(:given)} expected to be a kind of #{arg.fetch(:expected)}"
+      else raise ArgumentError, 'argument must be a string, regexp or hash'
+      end
+
+    assert_raises_with_message(Kind::Error, msg, &block)
+  end
+
+  def assert_kind_undefined(object)
+    assert_equal(Kind::Undefined, object)
   end
 end


### PR DESCRIPTION
### Refine the behavior of `Kind.of()`/`Kind.is()`, allowing the creation of type checkers dynamically.

```ruby
Kind.of(User, user) # <User ...>
Kind.of(User, {})   # Kind::Error ({} expected to be a kind of User)

Kind.of(Hash, {})   # {}
Kind.of(Hash, user) # Kind::Error (<User ...> expected to be a kind of Hash)

# ---

kind_of_user = Kind.of(User)

kind_of_user.or_nil({}) # nil

kind_of_user.instance?({})   # false
kind_of_user.instance?(User) # true

kind_of_user.class?(Hash)  # false
kind_of_user.class?(User)  # true

# Create type checkers dynamically is cheap
# because of a singleton object is created to be available for use.

kind_of_user.object_id == Kind.of(User).object_id # true

# --------------------------------------------- #
# Kind.is() can be used to check a class/module #
# --------------------------------------------- #

class Admin < User
end

Kind.is(Admin, User) # true
```

### Adds `Kind::Empty`

A bunch of frozen values as constants, that could be used as a default value.

- `Kind::Empty::SET`
- `Kind::Empty::HASH`
- `Kind::Empty::ARRAY`
- `Kind::Empty::STRING`

### Improve a lot of other things like: type checker features and optimizations.

Read the readme changes to know them! 😅 