### PR TITLE
[1.8.0] Add Kind.of.<Type>.{as_maybe,as_optional}

### DIFF
--- a/lib/kind.rb
+++ b/lib/kind.rb
@@ -88,7 +88,7 @@ module Kind
 
       def self.class?(value); Kind::Is.Class(value); end
 
-      def self.instance?(value); class?(value); end
+      def self.__is_instance__(value); class?(value); end
     end)
 
     # -- Module
@@ -128,13 +128,13 @@ module Kind
         if ::Kind::Maybe::Value.none?(default)
           __kind_undefined(value) { __kind_of(value) }
         else
-          return value if instance?(value)
+          return value if value != Kind::Undefined && instance?(value)
 
           __kind_undefined(default) { __kind_of(default) }
         end
       end
 
-      def self.instance?(value); class?(value); end
+      def self.__is_instance__(value); class?(value); end
     end)
 
     # -- Boolean
@@ -164,7 +164,7 @@ module Kind
         if ::Kind::Maybe::Value.none?(default)
           __kind_undefined(value) { Kind::Of::Boolean(value) }
         else
-          return value if instance?(value)
+          return value if value != Kind::Undefined && instance?(value)
 
           __kind_undefined(default) { Kind::Of::Boolean(default) }
         end
@@ -178,7 +178,7 @@ module Kind
         end
       end
 
-      def self.instance?(value);
+      def self.__is_instance__(value);
         value.is_a?(TrueClass) || value.is_a?(FalseClass)
       end
 
@@ -213,7 +213,7 @@ module Kind
         if ::Kind::Maybe::Value.none?(default)
           __kind_undefined(value) { Kind::Of::Lambda(value) }
         else
-          return value if instance?(value)
+          return value if value != Kind::Undefined && instance?(value)
 
           __kind_undefined(default) { Kind::Of::Lambda(default) }
         end
@@ -227,7 +227,7 @@ module Kind
         end
       end
 
-      def self.instance?(value)
+      def self.__is_instance__(value)
         value.is_a?(__kind) && value.lambda?
       end
     end)
@@ -261,7 +261,7 @@ module Kind
         if ::Kind::Maybe::Value.none?(default)
           __kind_undefined(value) { Kind::Of::Callable(value) }
         else
-          return value if instance?(value)
+          return value if value != Kind::Undefined && instance?(value)
 
           __kind_undefined(default) { Kind::Of::Callable(default) }
         end
@@ -275,7 +275,7 @@ module Kind
         end
       end
 
-      def self.instance?(value);
+      def self.__is_instance__(value);
         value.respond_to?(:call)
       end
     end)

--- a/lib/kind/checker.rb
+++ b/lib/kind/checker.rb
@@ -11,15 +11,26 @@ module Kind
 
       return Kind::Of.(__kind, value) if ::Kind::Maybe::Value.none?(default)
 
-      instance?(value) ? value : Kind::Of.(__kind, default)
+      value != Kind::Undefined && instance?(value) ? value : Kind::Of.(__kind, default)
     end
 
     def [](value, options = options = Empty::HASH)
       instance(value, options)
     end
 
-    def instance?(value)
+    def instance?(value = Kind::Undefined)
+      return __is_instance__(value) if value != Kind::Undefined
+
+      is_instance_to_proc
+    end
+
+    def __is_instance__(value)
       value.is_a?(__kind)
+    end
+
+    def is_instance_to_proc
+      @is_instance_to_proc ||=
+        -> checker { -> value { checker.__is_instance__(value) } }.call(self)
     end
 
     def or_nil(value)

--- a/lib/kind/checker.rb
+++ b/lib/kind/checker.rb
@@ -29,6 +29,25 @@ module Kind
     def or_undefined(value)
       or_nil(value) || Kind::Undefined
     end
+
+    def as_maybe(value = Kind::Undefined)
+      return __as_maybe__(value) if value != Kind::Undefined
+
+      as_maybe_to_proc
+    end
+
+    def as_optional(value = Kind::Undefined)
+      as_maybe(value)
+    end
+
+    def __as_maybe__(value)
+      Kind::Maybe.new(or_nil(value))
+    end
+
+    def as_maybe_to_proc
+      @as_maybe_to_proc ||=
+        -> checker { -> value { checker.__as_maybe__(value) } }.call(self)
+    end
   end
 
   private_constant :Checkable

--- a/lib/kind/maybe.rb
+++ b/lib/kind/maybe.rb
@@ -87,10 +87,10 @@ module Kind
 
       alias_method :then, :map
 
-      def try(method_name = Undefined, &block)
+      def try(method_name = Undefined, *args, &block)
         fn = method_name == Undefined ? block : Kind.of.Symbol(method_name).to_proc
 
-        result = fn.call(value)
+        result = args.empty? ? fn.call(value) : fn.call(*args.unshift(value))
 
         return result if Maybe::Value.some?(result)
       end

--- a/lib/kind/version.rb
+++ b/lib/kind/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Kind
-  VERSION = '1.7.0'
+  VERSION = '1.8.0'
 end

--- a/test/kind/maybe_test.rb
+++ b/test/kind/maybe_test.rb
@@ -183,6 +183,9 @@ class Kind::MaybeTest < Minitest::Test
     assert_nil(Kind::Maybe[Kind::Undefined].try(:upcase))
     assert_nil(Kind::Maybe[Kind::Undefined].try { |value| value.upcase })
 
+    assert_equal(0, Kind::Maybe[{}].try(:fetch, :number, 0))
+    assert_equal('BAR', Kind::Maybe[{bar: 'BAR'}].try(:fetch, :bar))
+
     assert_raises_with_message(Kind::Error, '"upcase" expected to be a kind of Symbol') do
       Kind::Maybe['foo'].try('upcase')
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -127,10 +127,20 @@ class Minitest::Test
         kind_checker.instance?(invalid_instance)
       end)
 
+      assert_equal(
+        0,
+        invalid_instances.select(&kind_checker.instance?).size
+      )
+
       assert(valid_instances.all? do |valid_instance|
         # Kind.of.String.instance?(:a) == false
         kind_checker.instance?(valid_instance)
       end)
+
+      assert_equal(
+        valid_instances.size,
+        valid_instances.select(&kind_checker.instance?).size
+      )
 
       #
       # Kind.of.<Type>.or_nil()

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -71,8 +71,8 @@ class Minitest::Test
   def assert_kind_checkers(kind_checker_from_method, kind_checker_from_constant, options)
     # { instance: { valid: ['a', 'b'], invalid: [:a, {}] } }
     instance_data = Kind.of.Hash(options.fetch(:instance))
-    valid_instances = Array(instance_data.fetch(:valid))     # ['a', 'b']
-    invalid_instances = Array(instance_data.fetch(:invalid)) # [:a, {}]
+    valid_instances = Array(instance_data.fetch(:valid))             # ['a', 'b']
+    invalid_instances = Array(instance_data.fetch(:invalid)) + [nil] # [:a, {}, nil]
 
     valid_instance1 = valid_instances[0]                    # 'a'
     valid_instance2 = valid_instances[1] || valid_instance1 # 'b'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -133,7 +133,7 @@ class Minitest::Test
       end)
 
       #
-      # Kind.of.<Type>.or_nil?()
+      # Kind.of.<Type>.or_nil()
       #
       # Kind.of.String.or_nil(:a) == nil
       assert_nil(kind_checker.or_nil(invalid_instances.sample))
@@ -141,7 +141,7 @@ class Minitest::Test
       assert_equal(valid_instance1, kind_checker.or_nil(valid_instance1))
 
       #
-      # Kind.of.<Type>.or_nil?()
+      # Kind.of.<Type>.or_undefined()
       #
       # Kind.of.String.or_undefined(:a) == Kind::Undefined
       assert_kind_undefined(kind_checker.or_undefined(invalid_instances.sample))
@@ -160,6 +160,28 @@ class Minitest::Test
         # Kind.of.String.class?(String) == true
         kind_checker.class?(class_or_mod)
       end)
+
+      #
+      # Kind.of.<Type>.as_maybe()
+      #
+      assert_instance_of(Kind::Maybe::None, kind_checker.as_maybe(invalid_instances.sample))
+
+      assert(invalid_instances.map(&kind_checker.as_maybe).all?(&:none?))
+
+      assert_instance_of(Kind::Maybe::Some, kind_checker.as_maybe(valid_instances.sample))
+
+      assert(valid_instances.map(&kind_checker.as_maybe).all?(&:some?))
+
+      #
+      # Kind.of.<Type>.as_optional()
+      #
+      assert_instance_of(Kind::Optional::None, kind_checker.as_optional(invalid_instances.sample))
+
+      assert(invalid_instances.map(&kind_checker.as_optional).all?(&:none?))
+
+      assert_instance_of(Kind::Optional::Some, kind_checker.as_optional(valid_instances.sample))
+
+      assert(valid_instances.map(&kind_checker.as_optional).all?(&:some?))
     end
 
     # Kind::Of::String === Kind.of.String


### PR DESCRIPTION
Closes #21 

---

- [x] Implement `Add Kind.of.<Type>.{as_maybe,as_optional}`
  - `as_maybe`/`as_optional` must returns a lambda if it was called without an argument.
- [x] Improve `Kind::Maybe#try` to receive the expected method arguments.
- [x] Improve `Kind.of.<Type>#instance?` to returns a lambda if it was called without an argument.
- [x] Bump version to 1.8.0
- [x] Update README