### PR TITLE
[1.9.0] Add Kind::Validator and Kind.of.<Type>.to_proc

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+bundle exec rake test
+
+ruby_v=$(ruby -v)
+
+ACTIVEMODEL_VERSION='3.2' bundle update && bundle exec rake test
+ACTIVEMODEL_VERSION='4.0' bundle update && bundle exec rake test
+ACTIVEMODEL_VERSION='4.1' bundle update && bundle exec rake test
+ACTIVEMODEL_VERSION='4.2' bundle update && bundle exec rake test
+ACTIVEMODEL_VERSION='5.0' bundle update && bundle exec rake test
+ACTIVEMODEL_VERSION='5.1' bundle update && bundle exec rake test
+
+if [[ ! $ruby_v =~ '2.2.0' ]]; then
+  ACTIVEMODEL_VERSION='5.2' bundle update && bundle exec rake test
+fi
+
+if [[ $ruby_v =~ '2.5.' ]] || [[ $ruby_v =~ '2.6.' ]] || [[ $ruby_v =~ '2.7.' ]]; then
+  ACTIVEMODEL_VERSION='6.0' bundle update && bundle exec rake test
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 ---
 language: ruby
 
+sudo: false
+
 cache: bundler
 
 rvm:
@@ -22,7 +24,7 @@ before_script:
   - chmod +x ./cc-test-reporter
   - "./cc-test-reporter before-build"
 
-script: bundle exec rake test
+script: "./.travis.sh"
 
 after_success:
   - "./cc-test-reporter after-build -t simplecov"

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,33 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
-# Specify your gem's dependencies in kind.gemspec
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+activemodel_version = ENV['ACTIVEMODEL_VERSION']
+
+activemodel = case activemodel_version
+              when '3.2' then '3.2.22'
+              when '4.0' then '4.0.13'
+              when '4.1' then '4.1.16'
+              when '4.2' then '4.2.11'
+              when '5.0' then '5.0.7'
+              when '5.1' then '5.1.7'
+              when '5.2' then '5.2.4'
+              when '6.0' then '6.0.0'
+              end
+
+group :test do
+  if activemodel_version
+    gem 'activesupport', activemodel, require: false
+    gem 'activemodel', activemodel, require: false
+    gem 'minitest', activemodel_version < '4.1' ? '~> 4.2' : '~> 5.0'
+  else
+    gem 'minitest', '~> 5.0'
+  end
+
+  gem 'simplecov', require: false
+end
+
+gem 'rake', '~> 13.0'
+
+# Specify your gem's dependencies in type_validator.gemspec
 gemspec
-
-gem "rake", "~> 12.0"
-gem "minitest", "~> 5.0"
-gem "simplecov", "~> 0.17.1"

--- a/kind.gemspec
+++ b/kind.gemspec
@@ -6,8 +6,8 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Rodrigo Serradura']
   spec.email         = ['rodrigo.serradura@gmail.com']
 
-  spec.summary       = %q{Basic type system for Ruby.}
-  spec.description   = %q{Basic type system for Ruby (free of dependencies).}
+  spec.summary       = %q{A simple type system (at runtime) for Ruby.}
+  spec.description   = %q{A simple type system (at runtime) for Ruby - free of dependencies.}
   spec.homepage      = 'https://github.com/serradura/kind'
   spec.license       = 'MIT'
   spec.required_ruby_version = Gem::Requirement.new('>= 2.2.0')

--- a/lib/kind/active_model/kind_validator.rb
+++ b/lib/kind/active_model/kind_validator.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+class KindValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if options[:allow_nil] && value.nil?
+
+    return unless error = call_validation_for(attribute, value)
+
+    raise Kind::Error.new("#{attribute} #{error}") if options[:strict]
+
+    record.errors.add(attribute, error)
+  end
+
+  private
+
+    def call_validation_for(attribute, value)
+      expected = options[:with] || options[:in]
+
+      return validate_with_default_strategy(expected, value) if expected
+
+      return kind_of(expected, value) if expected = options[:of] || options[:is_a]
+      return is_class(expected, value) if expected = options[:is] || options[:klass]
+      return respond_to(expected, value) if expected = options[:respond_to]
+      return instance_of(expected, value) if expected = options[:instance_of]
+      return array_with(expected, value) if expected = options[:array_with]
+      return array_of(expected, value) if expected = options[:array_of]
+
+      raise Kind::Validator::InvalidDefinition.new(attribute)
+    end
+
+    def validate_with_default_strategy(expected, value)
+      send(Kind::Validator.default_strategy, expected, value)
+    end
+
+    def instance_of(expected, value)
+      types = Array(expected)
+
+      return if types.any? { |type| value.instance_of?(type) }
+
+      "must be an instance of: #{types.map { |klass| klass.name }.join(', ')}"
+    end
+
+    def kind_of(expected, value)
+      types = Array(expected)
+
+      return if types.any? { |type| value.is_a?(type) }
+
+      "must be a kind of: #{types.map { |klass| klass.name }.join(', ')}"
+    end
+
+    def is_class(klass, value)
+      return if Kind.of.Class(value) == Kind.of.Class(klass) || value < klass
+
+      "must be the class or a subclass of `#{klass.name}`"
+    end
+
+    def respond_to(method_name, value)
+      return if value.respond_to?(method_name)
+
+      "must respond to the method `#{method_name}`"
+    end
+
+    def array_of(expected, value)
+      types = Array(expected)
+
+      return if value.is_a?(Array) && !value.empty? && value.all? { |value| types.any? { |type| value.is_a?(type) } }
+
+      "must be an array of: #{types.map { |klass| klass.name }.join(', ')}"
+    end
+
+    def array_with(expected, value)
+      return if value.is_a?(Array) && !value.empty? && (value - Kind.of.Array(expected)).empty?
+
+      "must be an array with: #{expected.join(', ')}"
+    end
+end

--- a/lib/kind/active_model/validation.rb
+++ b/lib/kind/active_model/validation.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'kind'
+require 'kind/validator'
+require 'active_model'
+require 'active_model/validations'
+require_relative 'kind_validator'

--- a/lib/kind/checker.rb
+++ b/lib/kind/checker.rb
@@ -21,15 +21,15 @@ module Kind
     def instance?(value = Kind::Undefined)
       return __is_instance__(value) if value != Kind::Undefined
 
-      is_instance_to_proc
+      to_proc
     end
 
     def __is_instance__(value)
       value.is_a?(__kind)
     end
 
-    def is_instance_to_proc
-      @is_instance_to_proc ||=
+    def to_proc
+      @to_proc ||=
         -> checker { -> value { checker.__is_instance__(value) } }.call(self)
     end
 

--- a/lib/kind/error.rb
+++ b/lib/kind/error.rb
@@ -2,8 +2,18 @@
 
 module Kind
   class Error < TypeError
-    def initialize(kind_name, object)
-      super("#{object.inspect} expected to be a kind of #{kind_name}")
+    UNDEFINED_OBJECT = Object.new
+
+    private_constant :UNDEFINED_OBJECT
+
+    def initialize(arg, object = UNDEFINED_OBJECT)
+      if object == UNDEFINED_OBJECT
+        # Will be used when the exception was raised with a message. e.g:
+        # raise Kind::Error, "some message"
+        super(arg)
+      else
+        super("#{object.inspect} expected to be a kind of #{arg}")
+      end
     end
   end
 end

--- a/lib/kind/validator.rb
+++ b/lib/kind/validator.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Kind
+  module Validator
+    DEFAULT_STRATEGIES = Set.new(%w[instance_of kind_of is_a]).freeze
+
+    class InvalidDefinition < ArgumentError
+      OPTIONS = 'Options to define one: :of, :instance_of, :respond_to, :klass, :array_of or :array_with'.freeze
+
+      def initialize(attribute)
+        super "invalid type definition for :#{attribute} attribute. #{OPTIONS}"
+      end
+
+      private_constant :OPTIONS
+    end
+
+    class InvalidDefaultStrategy < ArgumentError
+      OPTIONS =
+        DEFAULT_STRATEGIES.map { |option| ":#{option}" }.join(', ')
+
+      def initialize(option)
+        super "#{option.inspect} is an invalid option. Please use one of these: #{OPTIONS}"
+      end
+
+      private_constant :OPTIONS
+    end
+
+    def self.default_strategy
+      @default_strategy ||= :kind_of
+    end
+
+    def self.default_strategy=(option)
+      if DEFAULT_STRATEGIES.member?(String(option))
+        @default_strategy = option.to_sym
+      else
+        raise InvalidDefaultStrategy.new(option)
+      end
+    end
+  end
+end

--- a/lib/kind/version.rb
+++ b/lib/kind/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Kind
-  VERSION = '1.8.0'
+  VERSION = '1.9.0'
 end

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+bundle
+
+rm Gemfile.lock
+
+source $(dirname $0)/.travis.sh
+
+rm Gemfile.lock
+
+bundle

--- a/test/kind/active_model/validation/array_of_test.rb
+++ b/test/kind/active_model/validation/array_of_test.rb
@@ -1,0 +1,105 @@
+require 'test_helper'
+
+if ENV['ACTIVEMODEL_VERSION']
+  class KindActiveModelValidationArrayOfTest < Minitest::Test
+    class Person
+      include ActiveModel::Validations
+
+      attr_reader :values
+
+      validates :values, kind: { array_of: String }, allow_nil: true
+
+      def initialize(values:)
+        @values = values
+      end
+    end
+
+    def test_the_validation_with_a_single_type
+      [
+        Person.new(values: [1, 2, 3]),
+        Person.new(values: 'a'),
+        Person.new(values: [])
+      ].each do |person|
+        refute_predicate(person, :valid?)
+        assert_equal(['must be an array of: String'], person.errors[:values])
+      end
+
+      person = Person.new(values: %w[a b c])
+
+      assert_predicate(person, :valid?)
+    end
+
+    def test_the_allow_nil_validation_options
+      person = Person.new(values: nil)
+
+      assert_predicate(person, :valid?)
+    end
+
+    # ---
+
+    class Job
+      include ActiveModel::Validations
+
+      attr_reader :ids
+
+      validates :ids, kind: { array_of: [Integer, Float] }, allow_nil: true
+
+      def initialize(ids:)
+        @ids = ids
+      end
+    end
+
+    def test_the_validation_with_multiple_types
+      assert_predicate(Job.new(ids: nil), :valid?)
+
+      [
+        Job.new(ids: [1]),
+        Job.new(ids: [2, 3.0])
+      ].each do |job|
+        assert_predicate(job, :valid?)
+      end
+
+      [
+        Job.new(ids: ['a']),
+        Job.new(ids: 1),
+        Job.new(ids: [])
+      ].each do |job|
+        refute_predicate(job, :valid?)
+        assert_equal(['must be an array of: Integer, Float'], job.errors[:ids])
+      end
+    end
+
+    # ---
+
+    class Task
+      include ActiveModel::Validations
+
+      attr_reader :statuses
+
+      validates! :statuses, kind: { array_of: String }, allow_nil: true
+
+      def initialize(statuses:)
+        @statuses = statuses
+      end
+    end
+
+    def test_strict_validations
+      [
+        Task.new(statuses: nil),
+        Task.new(statuses: ['foo', 'bar'])
+      ].each do |task|
+        assert_predicate(task, :valid?)
+      end
+
+      [
+        Task.new(statuses: 1),
+        Task.new(statuses: []),
+        Task.new(statuses: [1])
+      ].each do |task|
+        assert_raises_kind_error('statuses must be an array of: String') do
+          task.valid?
+        end
+      end
+    end
+  end
+end

--- a/test/kind/active_model/validation/array_with_test.rb
+++ b/test/kind/active_model/validation/array_with_test.rb
@@ -1,0 +1,91 @@
+require 'test_helper'
+
+if ENV['ACTIVEMODEL_VERSION']
+  class KindActiveModelValidationArrayWithTest < Minitest::Test
+    class Person
+      include ActiveModel::Validations
+
+      attr_reader :values
+
+      validates :values, kind: { array_with: [1, 2, 3] }, allow_nil: true
+
+      def initialize(values:)
+        @values = values
+      end
+    end
+
+    def test_the_array_with_validation
+      [
+        Person.new(values: [4]),
+        Person.new(values: 1),
+        Person.new(values: [1, 2, 3, 5])
+      ].each do |person|
+        refute_predicate(person, :valid?)
+        assert_equal(['must be an array with: 1, 2, 3'], person.errors[:values])
+      end
+
+      person = Person.new(values: [1])
+
+      assert_predicate(person, :valid?)
+    end
+
+    def test_the_allow_nil_validation_options
+      person = Person.new(values: nil)
+
+      assert_predicate(person, :valid?)
+    end
+
+    # ---
+
+    class Task
+      include ActiveModel::Validations
+
+      attr_reader :values
+
+      validates! :values, kind: { array_with: [1, 2, 3] }, allow_nil: true
+
+      def initialize(values:)
+        @values = values
+      end
+    end
+
+    def test_strict_validations
+      [
+        Task.new(values: nil),
+        Task.new(values: [2, 3])
+      ].each do |task|
+        assert_predicate(task, :valid?)
+      end
+
+      [
+        Task.new(values: 1),
+        Task.new(values: []),
+        Task.new(values: [4])
+      ].each do |task|
+        assert_raises_kind_error('values must be an array with: 1, 2, 3') do
+          task.valid?
+        end
+      end
+    end
+
+    # ---
+
+    class Foo
+      include ActiveModel::Validations
+
+      attr_reader :values
+
+      validates! :values, kind: { array_with: 42 }, allow_nil: true
+
+      def initialize(values:)
+        @values = values
+      end
+    end
+
+    def test_the_validation_argument_error
+      assert_raises_kind_error('42 expected to be a kind of Array') do
+        Foo.new(values: [1]).valid?
+      end
+    end
+  end
+end

--- a/test/kind/active_model/validation/errors_test.rb
+++ b/test/kind/active_model/validation/errors_test.rb
@@ -1,0 +1,63 @@
+require 'test_helper'
+
+if ENV['ACTIVEMODEL_VERSION']
+  class KindActiveModelValidationErrorsTest < Minitest::Test
+    class InvalidValidation
+      include ActiveModel::Validations
+
+      attr_reader :name
+
+      validates :name, kind: {}
+    end
+
+    class InvalidValidationWithNil
+      include ActiveModel::Validations
+
+      attr_reader :name
+
+      validates :name, kind: { name: nil }
+    end
+
+    class InvalidValidationWithAnEmptyArray
+      include ActiveModel::Validations
+
+      attr_reader :name
+
+      validates :name, kind: { name: [] }
+    end
+
+    def test_the_exception_raised_because_of_the_wrong_definition
+      expected_message = [
+        'invalid type definition for :name attribute.',
+        'Options to define one: :of, :instance_of, :respond_to, :klass, :array_of or :array_with'
+      ].join(' ')
+
+      [
+        InvalidValidation.new,
+        InvalidValidationWithNil.new,
+        InvalidValidationWithAnEmptyArray.new
+      ].each do |instance|
+        assert_raises_with_message(Kind::Validator::InvalidDefinition, expected_message) do
+          instance.valid?
+        end
+      end
+    end
+
+    def test_the_exception_raised_because_of_a_wrong_default
+      expected_message = [
+        'invalid type definition for :name attribute.',
+        'Options to define one: :of, :instance_of, :respond_to, :klass, :array_of or :array_with'
+      ].join(' ')
+
+      [
+        InvalidValidation.new,
+        InvalidValidationWithNil.new,
+        InvalidValidationWithAnEmptyArray.new
+      ].each do |instance|
+        assert_raises_with_message(Kind::Validator::InvalidDefinition, expected_message) do
+          instance.valid?
+        end
+      end
+    end
+  end
+end

--- a/test/kind/active_model/validation/instance_of_test.rb
+++ b/test/kind/active_model/validation/instance_of_test.rb
@@ -1,0 +1,100 @@
+require 'test_helper'
+
+if ENV['ACTIVEMODEL_VERSION']
+  class KindActiveModelValidationInstanceOfTest < Minitest::Test
+    class Person
+      include ActiveModel::Validations
+
+      attr_reader :name, :age
+
+      validates :name, kind: { instance_of: String }
+      validates :age, kind: { instance_of: Float }
+
+      def initialize(name:, age:)
+        @name, @age = name, age
+      end
+    end
+
+    def test_the_validation_with_a_single_type
+      invalid_person = Person.new(name: 21.0, age: 'John')
+
+      refute_predicate(invalid_person, :valid?)
+      assert_equal(['must be an instance of: String'], invalid_person.errors[:name])
+      assert_equal(['must be an instance of: Float'], invalid_person.errors[:age])
+
+      person = Person.new(name: 'John', age: 21.0)
+
+      assert_predicate(person, :valid?)
+    end
+
+    class MyString < String; end
+
+    def test_that_will_be_invalid_when_checks_a_subclass
+      person = Person.new(name: MyString.new('John'), age: 21)
+
+      refute_predicate(person, :valid?)
+
+      assert_equal(['must be an instance of: String'], person.errors[:name])
+    end
+
+    # ---
+
+    class Job
+      include ActiveModel::Validations
+
+      attr_reader :id, :status
+
+      validates :id, kind: { instance_of: Float }, allow_nil: true
+      validates :status, kind: { instance_of: [String, Symbol] }
+
+      def initialize(status:, id: nil)
+        @status, @id = status, id
+      end
+    end
+
+    def test_the_validation_with_multiple_types
+      job1 = Job.new(id: 1.0, status: 'sleeping')
+      job2 = Job.new(id: 2.0, status: :sleeping)
+      job3 = Job.new(id: 3.0, status: 0)
+
+      assert_predicate(job1, :valid?)
+      assert_predicate(job2, :valid?)
+
+      refute_predicate(job3, :valid?)
+      assert_equal(['must be an instance of: String, Symbol'], job3.errors[:status])
+    end
+
+    def test_the_allow_nil_validation_options
+      job1 = Job.new(status: 'sleeping')
+      job2 = Job.new(id: '3', status: 'sleeping')
+
+      assert_predicate(job1, :valid?)
+
+      refute_predicate(job2, :valid?)
+      assert_equal(['must be an instance of: Float'], job2.errors[:id])
+    end
+
+    # ---
+
+    class Task
+      include ActiveModel::Validations
+
+      attr_reader :title
+
+      validates! :title, kind: { instance_of: String }, allow_nil: true
+
+      def initialize(title:)
+        @title = title
+      end
+    end
+
+    def test_strict_validations
+      assert_predicate(Task.new(title: nil), :valid?)
+      assert_predicate(Task.new(title: 'Buy milk'), :valid?)
+
+      assert_raises_kind_error('title must be an instance of: String') do
+        Task.new(title: 42).valid?
+      end
+    end
+  end
+end

--- a/test/kind/active_model/validation/is_a_test.rb
+++ b/test/kind/active_model/validation/is_a_test.rb
@@ -1,0 +1,98 @@
+require 'test_helper'
+
+if ENV['ACTIVEMODEL_VERSION']
+  class KindActiveModelValidationIsATest < Minitest::Test
+    class Person
+      include ActiveModel::Validations
+
+      attr_reader :name, :age
+
+      validates :name, kind: { is_a: String }
+      validates :age, kind: { is_a: Integer }
+
+      def initialize(name:, age:)
+        @name, @age = name, age
+      end
+    end
+
+    def test_the_validation_with_a_single_type
+      invalid_person = Person.new(name: 21, age: 'John')
+
+      refute_predicate(invalid_person, :valid?)
+      assert_equal(['must be a kind of: String'], invalid_person.errors[:name])
+      assert_equal(['must be a kind of: Integer'], invalid_person.errors[:age])
+
+      person = Person.new(name: 'John', age: 21)
+
+      assert_predicate(person, :valid?)
+    end
+
+    class MyString < String; end
+
+    def test_that_will_be_valid_when_checks_a_subclass
+      person = Person.new(name: MyString.new('John'), age: 21)
+
+      assert_predicate(person, :valid?)
+    end
+
+    # ---
+
+    class Job
+      include ActiveModel::Validations
+
+      attr_reader :id, :status
+
+      validates :id, kind: { is_a: Integer }, allow_nil: true
+      validates :status, kind: { is_a: [String, Symbol] }
+
+      def initialize(status:, id: nil)
+        @status, @id = status, id
+      end
+    end
+
+    def test_the_validation_with_multiple_types
+      job1 = Job.new(id: 1, status: 'sleeping')
+      job2 = Job.new(id: 2, status: :sleeping)
+      job3 = Job.new(id: 3, status: 0)
+
+      assert_predicate(job1, :valid?)
+      assert_predicate(job2, :valid?)
+
+      refute_predicate(job3, :valid?)
+      assert_equal(['must be a kind of: String, Symbol'], job3.errors[:status])
+    end
+
+    def test_the_allow_nil_validation_options
+      job1 = Job.new(status: 'sleeping')
+      job2 = Job.new(id: '3', status: 'sleeping')
+
+      assert_predicate(job1, :valid?)
+
+      refute_predicate(job2, :valid?)
+      assert_equal(['must be a kind of: Integer'], job2.errors[:id])
+    end
+
+    # ---
+
+    class Task
+      include ActiveModel::Validations
+
+      attr_reader :title
+
+      validates! :title, kind: { is_a: String }, allow_nil: true
+
+      def initialize(title:)
+        @title = title
+      end
+    end
+
+    def test_strict_validations
+      assert_predicate(Task.new(title: nil), :valid?)
+      assert_predicate(Task.new(title: 'Buy milk'), :valid?)
+
+      assert_raises_kind_error('title must be a kind of: String') do
+        Task.new(title: 42).valid?
+      end
+    end
+  end
+end

--- a/test/kind/active_model/validation/kind_is_test.rb
+++ b/test/kind/active_model/validation/kind_is_test.rb
@@ -1,0 +1,88 @@
+require 'test_helper'
+
+if ENV['ACTIVEMODEL_VERSION']
+  class KindActiveModelValidationKindIsTest < Minitest::Test
+    BaseHandler = Class.new
+    TaskHandler = Class.new(BaseHandler)
+
+    class Person
+      include ActiveModel::Validations
+
+      attr_reader :handler
+
+      validates :handler, kind: { is: BaseHandler }, allow_nil: true
+
+      def initialize(handler:)
+        @handler = handler
+      end
+    end
+
+    def test_the_klass_validation
+      invalid_person = Person.new(handler: Hash)
+
+      refute_predicate(invalid_person, :valid?)
+      assert_equal(
+        ['must be the class or a subclass of `KindActiveModelValidationKindIsTest::BaseHandler`'],
+        invalid_person.errors[:handler]
+      )
+
+      person = Person.new(handler: BaseHandler)
+
+      assert_predicate(person, :valid?)
+    end
+
+    def test_the_allow_nil_validation_options
+      person = Person.new(handler: nil)
+
+      assert_predicate(person, :valid?)
+    end
+
+    # ---
+
+    class Task
+      include ActiveModel::Validations
+
+      attr_reader :handler
+
+      validates! :handler, kind: { is: BaseHandler }, allow_nil: true
+
+      def initialize(handler:)
+        @handler = handler
+      end
+    end
+
+    def test_strict_validations
+      assert_predicate(Task.new(handler: nil), :valid?)
+      assert_predicate(Task.new(handler: BaseHandler), :valid?)
+      assert_predicate(Task.new(handler: TaskHandler), :valid?)
+
+      assert_raises_kind_error(
+        'handler must be the class or a subclass of `KindActiveModelValidationKindIsTest::BaseHandler`'
+      ) { Task.new(handler: Array).valid? }
+    end
+
+    # ---
+
+    class Foo
+      include ActiveModel::Validations
+
+      attr_reader :handler
+
+      validates! :handler, kind: { is: 42 }, allow_nil: true
+
+      def initialize(handler:)
+        @handler = handler
+      end
+    end
+
+    def test_the_validation_argument_error
+      assert_raises_kind_error("42 expected to be a kind of Class") do
+        Foo.new(handler: Array).valid?
+      end
+
+      assert_raises_kind_error("[] expected to be a kind of Class") do
+        Foo.new(handler: []).valid?
+      end
+    end
+  end
+end

--- a/test/kind/active_model/validation/kind_of_test.rb
+++ b/test/kind/active_model/validation/kind_of_test.rb
@@ -1,0 +1,98 @@
+require 'test_helper'
+
+if ENV['ACTIVEMODEL_VERSION']
+  class KindActiveModelValidationKindOfTest < Minitest::Test
+    class Person
+      include ActiveModel::Validations
+
+      attr_reader :name, :age
+
+      validates :name, kind: { of: String }
+      validates :age, kind: { of: Integer }
+
+      def initialize(name:, age:)
+        @name, @age = name, age
+      end
+    end
+
+    def test_the_validation_with_a_single_type
+      invalid_person = Person.new(name: 21, age: 'John')
+
+      refute_predicate(invalid_person, :valid?)
+      assert_equal(['must be a kind of: String'], invalid_person.errors[:name])
+      assert_equal(['must be a kind of: Integer'], invalid_person.errors[:age])
+
+      person = Person.new(name: 'John', age: 21)
+
+      assert_predicate(person, :valid?)
+    end
+
+    class MyString < String; end
+
+    def test_that_will_be_valid_when_checks_a_subclass
+      person = Person.new(name: MyString.new('John'), age: 21)
+
+      assert_predicate(person, :valid?)
+    end
+
+    # ---
+
+    class Job
+      include ActiveModel::Validations
+
+      attr_reader :id, :status
+
+      validates :id, kind: { of: Integer }, allow_nil: true
+      validates :status, kind: { of: [String, Symbol] }
+
+      def initialize(status:, id: nil)
+        @status, @id = status, id
+      end
+    end
+
+    def test_the_validation_with_multiple_types
+      job1 = Job.new(id: 1, status: 'sleeping')
+      job2 = Job.new(id: 2, status: :sleeping)
+      job3 = Job.new(id: 3, status: 0)
+
+      assert_predicate(job1, :valid?)
+      assert_predicate(job2, :valid?)
+
+      refute_predicate(job3, :valid?)
+      assert_equal(['must be a kind of: String, Symbol'], job3.errors[:status])
+    end
+
+    def test_the_allow_nil_validation_options
+      job1 = Job.new(status: 'sleeping')
+      job2 = Job.new(id: '3', status: 'sleeping')
+
+      assert_predicate(job1, :valid?)
+
+      refute_predicate(job2, :valid?)
+      assert_equal(['must be a kind of: Integer'], job2.errors[:id])
+    end
+
+    # ---
+
+    class Task
+      include ActiveModel::Validations
+
+      attr_reader :title
+
+      validates! :title, kind: { of: String }, allow_nil: true
+
+      def initialize(title:)
+        @title = title
+      end
+    end
+
+    def test_strict_validations
+      assert_predicate(Task.new(title: nil), :valid?)
+      assert_predicate(Task.new(title: 'Buy milk'), :valid?)
+
+      assert_raises_kind_error('title must be a kind of: String') do
+        Task.new(title: 42).valid?
+      end
+    end
+  end
+end

--- a/test/kind/active_model/validation/klass_test.rb
+++ b/test/kind/active_model/validation/klass_test.rb
@@ -1,0 +1,88 @@
+require 'test_helper'
+
+if ENV['ACTIVEMODEL_VERSION']
+  class KindActiveModelValidationKlassTest < Minitest::Test
+    BaseHandler = Class.new
+    TaskHandler = Class.new(BaseHandler)
+
+    class Person
+      include ActiveModel::Validations
+
+      attr_reader :handler
+
+      validates :handler, kind: { klass: BaseHandler }, allow_nil: true
+
+      def initialize(handler:)
+        @handler = handler
+      end
+    end
+
+    def test_the_klass_validation
+      invalid_person = Person.new(handler: Hash)
+
+      refute_predicate(invalid_person, :valid?)
+      assert_equal(
+        ['must be the class or a subclass of `KindActiveModelValidationKlassTest::BaseHandler`'],
+        invalid_person.errors[:handler]
+      )
+
+      person = Person.new(handler: BaseHandler)
+
+      assert_predicate(person, :valid?)
+    end
+
+    def test_the_allow_nil_validation_options
+      person = Person.new(handler: nil)
+
+      assert_predicate(person, :valid?)
+    end
+
+    # ---
+
+    class Task
+      include ActiveModel::Validations
+
+      attr_reader :handler
+
+      validates! :handler, kind: { klass: BaseHandler }, allow_nil: true
+
+      def initialize(handler:)
+        @handler = handler
+      end
+    end
+
+    def test_strict_validations
+      assert_predicate(Task.new(handler: nil), :valid?)
+      assert_predicate(Task.new(handler: BaseHandler), :valid?)
+      assert_predicate(Task.new(handler: TaskHandler), :valid?)
+
+      assert_raises_kind_error(
+        'handler must be the class or a subclass of `KindActiveModelValidationKlassTest::BaseHandler`'
+      ) { Task.new(handler: Array).valid? }
+    end
+
+    # ---
+
+    class Foo
+      include ActiveModel::Validations
+
+      attr_reader :handler
+
+      validates! :handler, kind: { klass: 42 }, allow_nil: true
+
+      def initialize(handler:)
+        @handler = handler
+      end
+    end
+
+    def test_the_validation_argument_error
+      assert_raises_kind_error("42 expected to be a kind of Class") do
+        Foo.new(handler: Array).valid?
+      end
+
+      assert_raises_kind_error("[] expected to be a kind of Class") do
+        Foo.new(handler: []).valid?
+      end
+    end
+  end
+end

--- a/test/kind/active_model/validation/respond_to_test.rb
+++ b/test/kind/active_model/validation/respond_to_test.rb
@@ -1,0 +1,57 @@
+require 'test_helper'
+
+if ENV['ACTIVEMODEL_VERSION']
+  class KindActiveModelValidationRespondToTest < Minitest::Test
+    class Person
+      include ActiveModel::Validations
+
+      attr_reader :handler
+
+      validates :handler, kind: { respond_to: :call }, allow_nil: true
+
+      def initialize(handler:)
+        @handler = handler
+      end
+    end
+
+    def test_the_respond_to_validation
+      invalid_person = Person.new(handler: 21)
+
+      refute_predicate(invalid_person, :valid?)
+      assert_equal(['must respond to the method `call`'], invalid_person.errors[:handler])
+
+      person = Person.new(handler: -> {})
+
+      assert_predicate(person, :valid?)
+    end
+
+    def test_the_allow_nil_validation_options
+      person = Person.new(handler: nil)
+
+      assert_predicate(person, :valid?)
+    end
+
+    # ---
+
+    class Task
+      include ActiveModel::Validations
+
+      attr_reader :handler
+
+      validates! :handler, kind: { respond_to: :call }, allow_nil: true
+
+      def initialize(handler:)
+        @handler = handler
+      end
+    end
+
+    def test_strict_validations
+      assert_predicate(Task.new(handler: nil), :valid?)
+      assert_predicate(Task.new(handler: -> {}), :valid?)
+
+      assert_raises_kind_error('handler must respond to the method `call`') do
+        Task.new(handler: 42).valid?
+      end
+    end
+  end
+end

--- a/test/kind/of_test.rb
+++ b/test/kind/of_test.rb
@@ -41,6 +41,8 @@ class Kind::OfTest < Minitest::Test
 
     kind_of_bar = Kind.of(Bar)
 
+    assert_equal(@bar, [@bar, @foo_bar].select(&kind_of_bar).first)
+
     assert_raises_kind_error(given: 'nil', expected: 'Bar') { kind_of_bar.instance(nil) }
     assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Bar') { kind_of_bar.instance(Kind::Undefined) }
     assert_raises_kind_error(given: ':a', expected: 'Bar') { kind_of_bar.instance(:a) }
@@ -75,6 +77,8 @@ class Kind::OfTest < Minitest::Test
     # ---
 
     kind_of_foo_bar = Kind.of(Foo::Bar)
+
+    assert_equal(@foo_bar, [@bar, @foo_bar].select(&kind_of_foo_bar).first)
 
     assert_raises_kind_error(given: 'nil', expected: 'Foo::Bar') { kind_of_foo_bar.instance(nil) }
     assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Foo::Bar') { kind_of_foo_bar.instance(Kind::Undefined) }

--- a/test/kind/validator/default_strategy_test.rb
+++ b/test/kind/validator/default_strategy_test.rb
@@ -1,0 +1,86 @@
+require 'test_helper'
+
+if ENV['ACTIVEMODEL_VERSION']
+  class KindActiveModelValidationDefaultStrategyTest < Minitest::Test
+    class MyString < String; end
+
+    class Person
+      include ActiveModel::Validations
+
+      attr_reader :name
+
+      validates :name, kind: String
+
+      def initialize(name:)
+        @name = name
+      end
+    end
+
+    def test_the_default_strategy
+      invalid_person = Person.new(name: 21)
+
+      refute_predicate(invalid_person, :valid?)
+      assert_equal(['must be a kind of: String'], invalid_person.errors[:name])
+
+      person = Person.new(name: MyString.new('John'))
+
+      assert_predicate(person, :valid?)
+    end
+
+    def test_a_new_default_strategy
+      default_strategy = Kind::Validator.default_strategy
+
+      Kind::Validator.default_strategy = 'instance_of'
+
+      [
+        Person.new(name: 21),
+        Person.new(name: MyString.new('John'))
+      ].each do |person|
+        refute_predicate(person, :valid?)
+        assert_equal(['must be an instance of: String'], person.errors[:name])
+      end
+
+      Kind::Validator.default_strategy = :kind_of
+
+      [
+        Person.new(name: MyString.new('John'))
+      ].each { |person| assert_predicate(person, :valid?) }
+
+      Kind::Validator.default_strategy = default_strategy
+    end
+
+    # ---
+
+    class User
+      include ActiveModel::Validations
+
+      attr_reader :name
+
+      validates :name, kind: [String, Symbol], allow_nil: true
+
+      def initialize(name:)
+        @name = name
+      end
+    end
+
+    def test_the_default_strategy_with_multiple_classes
+      invalid_user = User.new(name: 21)
+
+      refute_predicate(invalid_user, :valid?)
+      assert_equal(['must be a kind of: String, Symbol'], invalid_user.errors[:name])
+
+      [
+        User.new(name: :John),
+        User.new(name: 'John'),
+        User.new(name: nil)
+      ].each { |user| assert_predicate(user, :valid?) }
+    end
+
+    def test_the_invalid_default_strategy_error
+      assert_raises_with_message(
+        Kind::Validator::InvalidDefaultStrategy,
+        ':bar is an invalid option. Please use one of these: :instance_of, :kind_of, :is_a'
+      ) { Kind::Validator.default_strategy = :bar }
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -105,6 +105,14 @@ class Minitest::Test
       kind_checker_from_constant
     ].each do |kind_checker|
       #
+      # Kind.of.<Type>.to_proc()
+      #
+      assert_equal(
+        valid_instances.size,
+        (valid_instances + invalid_instances).select(&kind_checker).size
+      )
+
+      #
       # Kind.of.<Type>.instance()
       #
       # Kind.of.String.instance(nil) # raise Kind::Error, "nil expected to be a kind of String"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,14 +1,30 @@
 require 'simplecov'
 
 SimpleCov.start do
-  add_filter "/test/"
+  add_filter '/test/'
+  add_filter '/lib/kind/active_model/validation.rb'
 end
 
-$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
-require "kind"
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
-require "minitest/pride"
-require "minitest/autorun"
+require 'kind'
+
+ENV.fetch('ACTIVEMODEL_VERSION', '6.1.0').tap do |active_model_version|
+  if active_model_version < '6.1.0'
+    require 'kind/active_model/validation'
+
+    if active_model_version < '4.1'
+      require 'minitest/unit'
+
+      module Minitest
+        Test = MiniTest::Unit::TestCase
+      end
+    end
+  end
+end
+
+require 'minitest/pride'
+require 'minitest/autorun'
 
 class Minitest::Test
   def assert_raises_with_message(exception, msg, &block)


### PR DESCRIPTION
- [x] Add `Kind::Validator` (`KindValidator`) as the [`type_validator`](https://github.com/serradura/type_validator) substitute.

- [x] Add `Kind.of.<Type>.to_proc` quack like `Kind.of.<Type>.instance?`.
```ruby
collection
  .select &Kind.of.Hash

collection
  .select &Kind.of.Hash.instance?
```

- [x] Bump version to 1.9.0 

- [x] Update README

- [ ] Update type_validator's README about the `Kind::Validator` and the project descontinuation.