### PR TITLE
[2.1.0] Improving existing features

### DIFF
--- a/lib/kind.rb
+++ b/lib/kind.rb
@@ -29,6 +29,12 @@ module Kind
 
   private_constant :MODULE_OR_CLASS
 
+  private_class_method def self.__checkers__
+    @__checkers__ ||= {}
+  end
+
+  __checkers__
+
   def self.of(kind = Undefined, object = Undefined)
     return Of if kind == Undefined && object == Undefined
 
@@ -45,8 +51,8 @@ module Kind
     end
   end
 
-  private_class_method def self.__checkers__
-    @__checkers__ ||= {}
+  def self.of?(kind, *args)
+    Kind.of(kind).instance?(*args)
   end
 
   # --------------------- #

--- a/lib/kind.rb
+++ b/lib/kind.rb
@@ -90,6 +90,10 @@ module Kind
       def self.__is_instance__(value); class?(value); end
     end)
 
+    def self.Class?(*args)
+      Kind::Of::Class.instance?(*args)
+    end
+
     # -- Module
 
     def self.Module(object = Undefined)
@@ -135,6 +139,10 @@ module Kind
 
       def self.__is_instance__(value); class?(value); end
     end)
+
+    def self.Module?(*args)
+      Kind::Of::Module.instance?(*args)
+    end
 
     # -- Boolean
 
@@ -187,6 +195,10 @@ module Kind
       end
     end)
 
+    def self.Boolean?(*args)
+      Kind::Of::Boolean.instance?(*args)
+    end
+
     # -- Lambda
 
     def self.Lambda(object = Undefined, options = Empty::HASH)
@@ -230,6 +242,10 @@ module Kind
         value.is_a?(__kind) && value.lambda?
       end
     end)
+
+    def self.Lambda?(*args)
+      Kind::Of::Lambda.instance?(*args)
+    end
 
     # -- Callable
 
@@ -278,6 +294,10 @@ module Kind
         value.respond_to?(:call)
       end
     end)
+
+    def self.Callable?(*args)
+      Kind::Of::Callable.instance?(*args)
+    end
 
     # ---------------------- #
     # Built-in type checkers #

--- a/lib/kind/checker.rb
+++ b/lib/kind/checker.rb
@@ -18,10 +18,13 @@ module Kind
       instance(value, options)
     end
 
-    def instance?(value = Kind::Undefined)
-      return __is_instance__(value) if value != Kind::Undefined
+    def instance?(*args)
+      return to_proc if args.empty?
 
-      to_proc
+      return args.all? { |object| __is_instance__(object) } if args.size > 1
+
+      arg = args[0]
+      arg == Kind::Undefined ? to_proc : __is_instance__(arg)
     end
 
     def __is_instance__(value)

--- a/lib/kind/maybe.rb
+++ b/lib/kind/maybe.rb
@@ -117,7 +117,7 @@ module Kind
     def self.some(value)
       return Maybe::Some.new(value) if Value.some?(value)
 
-      raise Kind::Error, VALUE_CANT_BE_NONE
+      raise ArgumentError, VALUE_CANT_BE_NONE
     end
   end
 

--- a/lib/kind/maybe.rb
+++ b/lib/kind/maybe.rb
@@ -16,7 +16,7 @@ module Kind
       attr_reader :value
 
       def initialize(value)
-        @value = value
+        @value = value.kind_of?(Result) ? value.value : value
       end
 
       def value_or(method_name = Undefined, &block)
@@ -79,6 +79,7 @@ module Kind
       def map(&fn)
         result = fn.call(@value)
 
+        return result if Maybe::None === result
         return NONE_WITH_NIL_VALUE if result == nil
         return NONE_WITH_UNDEFINED_VALUE if result == Undefined
 
@@ -98,7 +99,7 @@ module Kind
 
     def self.new(value)
       result_type = Maybe::Value.none?(value) ? None : Some
-      result_type.new(value.is_a?(Result) ? value.value : value)
+      result_type.new(value)
     end
 
     def self.[](value);

--- a/lib/kind/maybe.rb
+++ b/lib/kind/maybe.rb
@@ -67,7 +67,7 @@ module Kind
     NONE_WITH_NIL_VALUE = None.new(nil)
     NONE_WITH_UNDEFINED_VALUE = None.new(Undefined)
 
-    private_constant :NONE_WITH_UNDEFINED_VALUE
+    private_constant :NONE_WITH_NIL_VALUE, :NONE_WITH_UNDEFINED_VALUE
 
     class Some < Result
       def value_or(default = Undefined, &block)
@@ -104,13 +104,31 @@ module Kind
     def self.[](value);
       new(value)
     end
+
+    def self.none
+      NONE_WITH_NIL_VALUE
+    end
+
+    VALUE_CANT_BE_NONE = "value can't be nil or Kind::Undefined".freeze
+
+    private_constant :VALUE_CANT_BE_NONE
+
+    def self.some(value)
+      return Maybe::Some.new(value) if Value.some?(value)
+
+      raise Kind::Error, VALUE_CANT_BE_NONE
+    end
   end
 
   Optional = Maybe
 
-  None = Maybe::NONE_WITH_NIL_VALUE
+  None = Maybe.none
 
   def self.None
     Kind::None
+  end
+
+  def self.Some(value)
+    Maybe.some(value)
   end
 end

--- a/lib/kind/maybe.rb
+++ b/lib/kind/maybe.rb
@@ -67,7 +67,7 @@ module Kind
     NONE_WITH_NIL_VALUE = None.new(nil)
     NONE_WITH_UNDEFINED_VALUE = None.new(Undefined)
 
-    private_constant :NONE_WITH_NIL_VALUE, :NONE_WITH_UNDEFINED_VALUE
+    private_constant :NONE_WITH_UNDEFINED_VALUE
 
     class Some < Result
       def value_or(default = Undefined, &block)
@@ -107,4 +107,10 @@ module Kind
   end
 
   Optional = Maybe
+
+  None = Maybe::NONE_WITH_NIL_VALUE
+
+  def self.None
+    Kind::None
+  end
 end

--- a/lib/kind/maybe.rb
+++ b/lib/kind/maybe.rb
@@ -44,7 +44,7 @@ module Kind
       def value_or(default = Undefined, &block)
         raise ArgumentError, INVALID_DEFAULT_ARG if default == Undefined && !block
 
-        Maybe::Value.some?(default) ? default : block.call
+        default != Undefined ? default : block.call
       end
 
       def none?; true; end

--- a/lib/kind/types.rb
+++ b/lib/kind/types.rb
@@ -12,7 +12,11 @@ module Kind
 
         return Kind::Of::%{kind_name} if object == Undefined && default.nil?
 
-        Kind::Of.(::%{kind_name_to_check}, (object || default))
+        is_instance = Kind::Of::%{kind_name}.__is_instance__(object)
+
+        return object if is_instance
+
+        Kind::Of.(::%{kind_name_to_check}, object && default ? default : object || default)
       end
     RUBY
 

--- a/lib/kind/types.rb
+++ b/lib/kind/types.rb
@@ -16,6 +16,12 @@ module Kind
       end
     RUBY
 
+    KIND_OF_IS = <<-RUBY
+      def self.%{method_name}?(*args)
+        Kind::Of::%{kind_name}.instance?(*args)
+      end
+    RUBY
+
     KIND_IS = <<-RUBY
       def self.%{method_name}(value = Undefined)
         return Kind::Is::%{kind_name} if value == Undefined
@@ -93,6 +99,7 @@ module Kind
 
           kind_of_mod.instance_eval(KIND_OF % params)
           kind_of_mod.const_set(method_name, kind_checker)
+          kind_of_mod.instance_eval(KIND_OF_IS % params)
         end
 
         unless kind_is_mod.respond_to?(method_name)

--- a/lib/kind/version.rb
+++ b/lib/kind/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Kind
-  VERSION = '2.0.0'
+  VERSION = '2.1.0'
 end

--- a/test/kind/maybe_test.rb
+++ b/test/kind/maybe_test.rb
@@ -225,8 +225,37 @@ class Kind::MaybeTest < Minitest::Test
 
     assert_same(Kind::None, Kind.None)
 
+    # --
+
     assert_raises_with_message(ArgumentError, 'wrong number of arguments (given 1, expected 0)') do
       Kind::None(nil)
+    end
+  end
+
+  def test_the_kind_some_method
+    kind_some1 = Kind.Some(1)
+    kind_some2 = Kind::Some(1)
+
+    [kind_some1, kind_some2].each do |kind_some|
+      assert_instance_of(Kind::Maybe::Some, kind_some)
+
+      assert_equal(1, kind_some.value)
+    end
+
+    refute_same(kind_some1, kind_some2)
+
+    # --
+
+    assert_raises_with_message(ArgumentError, 'wrong number of arguments (given 0, expected 1)') do
+      Kind::Some()
+    end
+
+    # --
+
+    [nil, Kind::Undefined].each do |value|
+      assert_raises_with_message(Kind::Error, "value can't be nil or Kind::Undefined") do
+        Kind::Some(value)
+      end
     end
   end
 end

--- a/test/kind/maybe_test.rb
+++ b/test/kind/maybe_test.rb
@@ -215,4 +215,18 @@ class Kind::MaybeTest < Minitest::Test
 
     assert_equal(35, result2)
   end
+
+  def test_the_kind_none_method
+    [Kind.None, Kind::None].each do |kind_none|
+      assert_instance_of(Kind::Maybe::None, kind_none)
+
+      assert_nil(kind_none.value)
+    end
+
+    assert_same(Kind::None, Kind.None)
+
+    assert_raises_with_message(ArgumentError, 'wrong number of arguments (given 1, expected 0)') do
+      Kind::None(nil)
+    end
+  end
 end

--- a/test/kind/maybe_test.rb
+++ b/test/kind/maybe_test.rb
@@ -253,7 +253,7 @@ class Kind::MaybeTest < Minitest::Test
     # --
 
     [nil, Kind::Undefined].each do |value|
-      assert_raises_with_message(Kind::Error, "value can't be nil or Kind::Undefined") do
+      assert_raises_with_message(ArgumentError, "value can't be nil or Kind::Undefined") do
         Kind::Some(value)
       end
     end

--- a/test/kind/maybe_test.rb
+++ b/test/kind/maybe_test.rb
@@ -56,6 +56,10 @@ class Kind::MaybeTest < Minitest::Test
   end
 
   def test_maybe_value_or_default
+    assert_nil(Kind::Maybe[nil].value_or(nil))
+
+    # ---
+
     optional1 = Kind::Maybe.new(2)
 
     assert_equal(2, optional1.value_or(0))

--- a/test/kind/of_test.rb
+++ b/test/kind/of_test.rb
@@ -67,7 +67,23 @@ class Kind::OfTest < Minitest::Test
     # #instance?
     #
     refute kind_of_bar.instance?({})
+    refute kind_of_bar.instance?(@bar, {})
+
     assert kind_of_bar.instance?(@bar)
+    assert kind_of_bar.instance?(@bar, Bar.new)
+
+    assert_equal([@bar], [@bar, @foo_bar].select(&kind_of_bar.instance?))
+
+    #
+    # Kind.of?(<Type>, *args)
+    #
+    refute Kind.of?(Bar, {})
+    refute Kind.of?(Bar, @bar, {})
+
+    assert Kind.of?(Bar, @bar)
+    assert Kind.of?(Bar, @bar, Bar.new)
+
+    assert_equal([@bar], [@bar, @foo_bar].select(&Kind.of?(Bar)))
 
     #
     # #class?
@@ -129,7 +145,23 @@ class Kind::OfTest < Minitest::Test
     # #instance?
     #
     refute kind_of_foo_bar.instance?({})
+    refute kind_of_foo_bar.instance?(@foo_bar, {})
+
     assert kind_of_foo_bar.instance?(@foo_bar)
+    assert kind_of_foo_bar.instance?(@foo_bar, Foo::Bar.new)
+
+    assert_equal([@foo_bar], [@bar, @foo_bar].select(&kind_of_foo_bar.instance?))
+
+    #
+    # Kind.of?(<Type>, *args)
+    #
+    refute Kind.of?(Foo::Bar, {})
+    refute Kind.of?(Foo::Bar, @foo_bar, {})
+
+    assert Kind.of?(Foo::Bar, @foo_bar)
+    assert Kind.of?(Foo::Bar, @foo_bar, Foo::Bar.new)
+
+    assert_equal([@foo_bar], [@bar, @foo_bar].select(&Kind.of?(Foo::Bar)))
 
     #
     # #class?

--- a/test/kind/of_test.rb
+++ b/test/kind/of_test.rb
@@ -41,8 +41,18 @@ class Kind::OfTest < Minitest::Test
 
     kind_of_bar = Kind.of(Bar)
 
-    assert_equal(@bar, [@bar, @foo_bar].select(&kind_of_bar).first)
+    #
+    # #to_proc
+    #
+    assert_equal([@bar], [@bar].map(&kind_of_bar))
 
+    assert_raises_kind_error(given: @foo_bar.inspect, expected: 'Bar') do
+      [@bar, @foo_bar].map(&kind_of_bar)
+    end
+
+    #
+    # #instance
+    #
     assert_raises_kind_error(given: 'nil', expected: 'Bar') { kind_of_bar.instance(nil) }
     assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Bar') { kind_of_bar.instance(Kind::Undefined) }
     assert_raises_kind_error(given: ':a', expected: 'Bar') { kind_of_bar.instance(:a) }
@@ -53,33 +63,58 @@ class Kind::OfTest < Minitest::Test
     assert_raises_kind_error(given: 'nil', expected: 'Bar') { kind_of_bar.instance(nil, or: Kind::Undefined) }
     assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Bar') { kind_of_bar.instance(Kind::Undefined, or: nil) }
 
+    #
+    # #instance?
+    #
     refute kind_of_bar.instance?({})
     assert kind_of_bar.instance?(@bar)
 
+    #
+    # #class?
+    #
     assert_equal(false, kind_of_bar.class?(Hash))
     assert_equal(true, kind_of_bar.class?(Bar))
     assert_equal(true, kind_of_bar.class?(Class.new(Bar)))
 
+    #
+    # #or_nil
+    #
     assert_nil kind_of_bar.or_nil({})
     assert_equal(@bar, kind_of_bar.or_nil(@bar))
 
+    #
+    # #or_undefined
+    #
     assert_kind_undefined kind_of_bar.or_undefined({})
     assert_equal(@bar, kind_of_bar.or_undefined(@bar))
+
+    #
+    # #[]
+    #
+    kind_of_bar.stub(:instance, -> (obj, opt) { [obj, opt] }) do
+      assert_equal([@bar, {}], kind_of_bar[@bar])
+    end
 
     assert_same(kind_of_bar, Kind.of(Bar))
 
     assert_instance_of(Kind::Checker, kind_of_bar)
 
-    kind_of_bar.stub(:instance, -> (obj, opt) { [obj, opt] }) do
-      assert_equal([@bar, {}], kind_of_bar[@bar])
-    end
-
     # ---
 
     kind_of_foo_bar = Kind.of(Foo::Bar)
 
-    assert_equal(@foo_bar, [@bar, @foo_bar].select(&kind_of_foo_bar).first)
+    #
+    # #to_proc
+    #
+    assert_equal([@foo_bar], [@foo_bar].map(&kind_of_foo_bar))
 
+    assert_raises_kind_error(given: @bar.inspect, expected: 'Foo::Bar') do
+      [@foo_bar, @bar].map(&kind_of_foo_bar)
+    end
+
+    #
+    # #instance
+    #
     assert_raises_kind_error(given: 'nil', expected: 'Foo::Bar') { kind_of_foo_bar.instance(nil) }
     assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Foo::Bar') { kind_of_foo_bar.instance(Kind::Undefined) }
     assert_raises_kind_error(given: ':a', expected: 'Foo::Bar') { kind_of_foo_bar.instance(:a) }
@@ -90,26 +125,41 @@ class Kind::OfTest < Minitest::Test
     assert_raises_kind_error(given: 'nil', expected: 'Foo::Bar') { kind_of_foo_bar.instance(nil, or: Kind::Undefined) }
     assert_raises_kind_error(given: 'Kind::Undefined', expected: 'Foo::Bar') { kind_of_foo_bar.instance(Kind::Undefined, or: nil) }
 
+    #
+    # #instance?
+    #
     refute kind_of_foo_bar.instance?({})
     assert kind_of_foo_bar.instance?(@foo_bar)
 
+    #
+    # #class?
+    #
     assert_equal(false, kind_of_foo_bar.class?(Hash))
     assert_equal(true, kind_of_foo_bar.class?(Foo::Bar))
     assert_equal(true, kind_of_foo_bar.class?(Class.new(Foo::Bar)))
 
+    #
+    # #or_nil
+    #
     assert_nil kind_of_foo_bar.or_nil({})
     assert_equal(@foo_bar, kind_of_foo_bar.or_nil(@foo_bar))
 
+    #
+    # #or_undefined
+    #
     assert_kind_undefined kind_of_foo_bar.or_undefined({})
     assert_equal(@foo_bar, kind_of_foo_bar.or_undefined(@foo_bar))
+
+    #
+    # #[]
+    #
+    kind_of_foo_bar.stub(:instance, -> (obj, opt) { [obj, opt] }) do
+      assert_equal([@foo_bar, {}], kind_of_foo_bar[@foo_bar])
+    end
 
     assert_same(kind_of_foo_bar, Kind.of(Foo::Bar))
 
     assert_instance_of(Kind::Checker, kind_of_foo_bar)
-
-    kind_of_foo_bar.stub(:instance, -> (obj, opt) { [obj, opt] }) do
-      assert_equal([@foo_bar, {}], kind_of_foo_bar[@foo_bar])
-    end
 
     # ---
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -112,8 +112,12 @@ class Minitest::Test
       #
       assert_equal(
         valid_instances.size,
-        (valid_instances + invalid_instances).select(&kind_checker).size
+        valid_instances.map(&kind_checker).size
       )
+
+      assert_raises_kind_error(given: invalid_instances[0].inspect, expected: kind_name) do
+        (valid_instances + invalid_instances).select(&kind_checker)
+      end
 
       #
       # Kind.of.<Type>.instance()

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -149,9 +149,12 @@ class Minitest::Test
       # Kind.of.<Type>.instance?()
       #
       refute(invalid_instances.any? do |invalid_instance|
-        # Kind.of.String.instance?('b') == true
+        # Kind.of.String.instance?(:b) == false
         kind_checker.instance?(invalid_instance)
       end)
+
+      # Kind.of.String.instance?(:a, :b) == false
+      refute(kind_checker.instance?(*invalid_instances))
 
       assert_equal(
         0,
@@ -159,9 +162,12 @@ class Minitest::Test
       )
 
       assert(valid_instances.all? do |valid_instance|
-        # Kind.of.String.instance?(:a) == false
+        # Kind.of.String.instance?('a') == true
         kind_checker.instance?(valid_instance)
       end)
+
+      # Kind.of.String.instance?('a', 'b')
+      assert(kind_checker.instance?(*valid_instances))
 
       assert_equal(
         valid_instances.size,


### PR DESCRIPTION
Closes #25 

---

- [x] [NEW]  `Kind.of.<Type>.instance?(*args)`
- [x] [NEW] `Kind.of.<Type>?(*args)`
- [x] [NEW] `Kind::None()`
- [x] [NEW] `Kind::Some()`
- [x] [NEW] `Kind.of?(<Type>, *args)` === `Kind.of.<Type>.instance?(*args)`
- [x] [CHANGE] `Kind.of.<Type>.to_proc` === `Kind.of.<Type>.instance(value)` this change is because now will there is a method to verify if the given value is an instance (`Kind.of.<Type>?`) and it has a `to_proc` behavior when is called without arguments.
- [x] Update README
  - Improve `Kind::Maybe` examples.
- [x] Bump version to 2.1.0