### PR TITLE
[2.2.0] Improve equality checking

### DIFF
--- a/lib/kind.rb
+++ b/lib/kind.rb
@@ -18,9 +18,9 @@ module Kind
   private_constant :WRONG_NUMBER_OF_ARGUMENTS
 
   def self.is(expected = Undefined, object = Undefined)
-    return Is if expected == Undefined && object == Undefined
+    return Is if Undefined == expected && Undefined == object
 
-    return Kind::Is.(expected, object) if object != Undefined
+    return Kind::Is.(expected, object) if Undefined != object
 
     raise ArgumentError, WRONG_NUMBER_OF_ARGUMENTS
   end
@@ -36,9 +36,9 @@ module Kind
   __checkers__
 
   def self.of(kind = Undefined, object = Undefined)
-    return Of if kind == Undefined && object == Undefined
+    return Of if Undefined == kind && Undefined == object
 
-    return Kind::Of.(kind, object) if object != Undefined
+    return Kind::Of.(kind, object) if Undefined != object
 
     __checkers__[kind] ||= begin
       kind_name = kind.name
@@ -65,7 +65,7 @@ module Kind
     end
 
     def self.Module(value)
-      value == ::Module || (value.is_a?(::Module) && !self.Class(value))
+      ::Module == value || (value.is_a?(::Module) && !self.Class(value))
     end
 
     def self.Boolean(value)
@@ -81,7 +81,7 @@ module Kind
     # -- Class
 
     def self.Class(object = Undefined)
-      return Class if object == Undefined
+      return Class if Undefined == object
 
       self.call(::Class, object)
     end
@@ -103,7 +103,7 @@ module Kind
     # -- Module
 
     def self.Module(object = Undefined)
-      return Module if object == Undefined
+      return Module if Undefined == object
 
       self.call(::Module, object)
     end
@@ -112,7 +112,7 @@ module Kind
       extend Checkable
 
       def self.__kind_undefined(value)
-        __kind_error(Kind::Undefined) if value == Kind::Undefined
+        __kind_error(Kind::Undefined) if Kind::Undefined == value
 
         yield
       end
@@ -137,7 +137,7 @@ module Kind
         if ::Kind::Maybe::Value.none?(default)
           __kind_undefined(value) { __kind_of(value) }
         else
-          return value if value != Kind::Undefined && instance?(value)
+          return value if Kind::Undefined != value && instance?(value)
 
           __kind_undefined(default) { __kind_of(default) }
         end
@@ -155,7 +155,7 @@ module Kind
     def self.Boolean(object = Undefined, options = Empty::HASH)
       default = options[:or]
 
-      return Kind::Of::Boolean if object == Undefined && default.nil?
+      return Kind::Of::Boolean if Undefined == object && default.nil?
 
       bool = object.nil? ? default : object
 
@@ -177,14 +177,14 @@ module Kind
         if ::Kind::Maybe::Value.none?(default)
           __kind_undefined(value) { Kind::Of::Boolean(value) }
         else
-          return value if value != Kind::Undefined && instance?(value)
+          return value if Kind::Undefined != value && instance?(value)
 
           __kind_undefined(default) { Kind::Of::Boolean(default) }
         end
       end
 
       def self.__kind_undefined(value)
-        if value == Kind::Undefined
+        if Kind::Undefined == value
           raise Kind::Error.new('Boolean'.freeze, Kind::Undefined)
         else
           yield
@@ -210,7 +210,7 @@ module Kind
     def self.Lambda(object = Undefined, options = Empty::HASH)
       default = options[:or]
 
-      return Kind::Of::Lambda if object == Undefined && default.nil?
+      return Kind::Of::Lambda if Undefined == object && default.nil?
 
       func = object || default
 
@@ -230,14 +230,14 @@ module Kind
         if ::Kind::Maybe::Value.none?(default)
           __kind_undefined(value) { Kind::Of::Lambda(value) }
         else
-          return value if value != Kind::Undefined && instance?(value)
+          return value if Kind::Undefined != value && instance?(value)
 
           __kind_undefined(default) { Kind::Of::Lambda(default) }
         end
       end
 
       def self.__kind_undefined(value)
-        if value == Kind::Undefined
+        if Kind::Undefined == value
           raise Kind::Error.new('Lambda'.freeze, Kind::Undefined)
         else
           yield
@@ -258,7 +258,7 @@ module Kind
     def self.Callable(object = Undefined, options = Empty::HASH)
       default = options[:or]
 
-      return Kind::Of::Callable if object == Undefined && default.nil?
+      return Kind::Of::Callable if Undefined == object && default.nil?
 
       callable = object || default
 
@@ -282,14 +282,14 @@ module Kind
         if ::Kind::Maybe::Value.none?(default)
           __kind_undefined(value) { Kind::Of::Callable(value) }
         else
-          return value if value != Kind::Undefined && instance?(value)
+          return value if Kind::Undefined != value && instance?(value)
 
           __kind_undefined(default) { Kind::Of::Callable(default) }
         end
       end
 
       def self.__kind_undefined(value)
-        if value == Kind::Undefined
+        if Kind::Undefined == value
           raise Kind::Error.new('Callable'.freeze, Kind::Undefined)
         else
           yield

--- a/lib/kind/active_model/kind_validator.rb
+++ b/lib/kind/active_model/kind_validator.rb
@@ -53,12 +53,12 @@ class KindValidator < ActiveModel::EachValidator
     def kind_is_not(expected, value)
       case expected
       when Class
-        return if Kind.of.Class(value) == expected || value < expected
+        return if expected == Kind.of.Class(value) || value < expected
 
         "must be the class or a subclass of `#{expected.name}`"
       when Module
         return if value.kind_of?(Class) && value <= expected
-        return if Kind.of.Module(value) == expected || value.kind_of?(expected)
+        return if expected == Kind.of.Module(value) || value.kind_of?(expected)
 
         "must include the `#{expected.name}` module"
       else

--- a/lib/kind/checker.rb
+++ b/lib/kind/checker.rb
@@ -11,7 +11,7 @@ module Kind
 
       return Kind::Of.(__kind, value) if ::Kind::Maybe::Value.none?(default)
 
-      value != Kind::Undefined && instance?(value) ? value : Kind::Of.(__kind, default)
+      Kind::Undefined != value && instance?(value) ? value : Kind::Of.(__kind, default)
     end
 
     def [](value, options = options = Empty::HASH)
@@ -38,7 +38,7 @@ module Kind
       return args.all? { |object| __is_instance__(object) } if args.size > 1
 
       arg = args[0]
-      arg == Kind::Undefined ? is_instance_to_proc : __is_instance__(arg)
+      Kind::Undefined == arg ? is_instance_to_proc : __is_instance__(arg)
     end
 
     def or_nil(value)
@@ -59,7 +59,7 @@ module Kind
     end
 
     def as_maybe(value = Kind::Undefined)
-      return __as_maybe__(value) if value != Kind::Undefined
+      return __as_maybe__(value) if Kind::Undefined != value
 
       as_maybe_to_proc
     end

--- a/lib/kind/error.rb
+++ b/lib/kind/error.rb
@@ -7,7 +7,7 @@ module Kind
     private_constant :UNDEFINED_OBJECT
 
     def initialize(arg, object = UNDEFINED_OBJECT)
-      if object == UNDEFINED_OBJECT
+      if UNDEFINED_OBJECT == object
         # Will be used when the exception was raised with a message. e.g:
         # raise Kind::Error, "some message"
         super(arg)

--- a/lib/kind/maybe.rb
+++ b/lib/kind/maybe.rb
@@ -4,7 +4,7 @@ module Kind
   module Maybe
     module Value
       def self.none?(value)
-        value == nil || value == Undefined
+        value.nil? || Undefined == value
       end
 
       def self.some?(value)
@@ -42,9 +42,9 @@ module Kind
       INVALID_DEFAULT_ARG = 'the default value must be defined as an argument or block'.freeze
 
       def value_or(default = Undefined, &block)
-        raise ArgumentError, INVALID_DEFAULT_ARG if default == Undefined && !block
+        raise ArgumentError, INVALID_DEFAULT_ARG if Undefined == default && !block
 
-        default != Undefined ? default : block.call
+        Undefined != default ? default : block.call
       end
 
       def none?; true; end
@@ -56,7 +56,7 @@ module Kind
       alias_method :then, :map
 
       def try(method_name = Undefined, &block)
-        Kind.of.Symbol(method_name) if method_name != Undefined
+        Kind.of.Symbol(method_name) if Undefined != method_name
 
         nil
       end
@@ -80,8 +80,8 @@ module Kind
         result = fn.call(@value)
 
         return result if Maybe::None === result
-        return NONE_WITH_NIL_VALUE if result == nil
-        return NONE_WITH_UNDEFINED_VALUE if result == Undefined
+        return NONE_WITH_NIL_VALUE if result.nil?
+        return NONE_WITH_UNDEFINED_VALUE if Undefined == result
 
         Some.new(result)
       end
@@ -89,7 +89,7 @@ module Kind
       alias_method :then, :map
 
       def try(method_name = Undefined, *args, &block)
-        fn = method_name == Undefined ? block : Kind.of.Symbol(method_name).to_proc
+        fn = Undefined == method_name ? block : Kind.of.Symbol(method_name).to_proc
 
         result = args.empty? ? fn.call(value) : fn.call(*args.unshift(value))
 

--- a/lib/kind/types.rb
+++ b/lib/kind/types.rb
@@ -10,7 +10,7 @@ module Kind
       def self.%{method_name}(object = Undefined, options = Empty::HASH)
         default = options[:or]
 
-        return Kind::Of::%{kind_name} if object == Undefined && default.nil?
+        return Kind::Of::%{kind_name} if Undefined == object && default.nil?
 
         is_instance = Kind::Of::%{kind_name}.__is_instance__(object)
 
@@ -28,7 +28,7 @@ module Kind
 
     KIND_IS = <<-RUBY
       def self.%{method_name}(value = Undefined)
-        return Kind::Is::%{kind_name} if value == Undefined
+        return Kind::Is::%{kind_name} if Undefined == value
 
         Kind::Is.__call__(::%{kind_name_to_check}, value)
       end

--- a/lib/kind/undefined.rb
+++ b/lib/kind/undefined.rb
@@ -19,7 +19,7 @@ module Kind
     end
 
     def undefined.default(value, default)
-      return self if value != self
+      return self if self != value
 
       default.respond_to?(:call) ? default.call : default
     end

--- a/lib/kind/version.rb
+++ b/lib/kind/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Kind
-  VERSION = '2.1.0'
+  VERSION = '2.2.0'
 end


### PR DESCRIPTION
I've been using `Kind.of(ActiveRecord::Relation, some_ar_relation)` in one of my apps and I found an unexpected behavior, the relations were always been executed. 

![image](https://user-images.githubusercontent.com/305364/85420998-4a7af180-b54a-11ea-96b3-3247dcb80e29.png)

The reason is [`ActiveRecord::AssociationRelation#==`](https://github.com/rails/rails/blob/23e6743355b58a1bd49f62e7c6d211d6e1fa477a/activerecord/lib/active_record/association_relation.rb#L13) behavior, which always performs a query (`to_a`). So, to avoid this and other unexpected behaviors, I decided to invert the comparison with `Kind::Undefined` to ensure a regular equality checking.
