### PR TITLE
[3.0.0] Change Kind::Maybe::Result#try() method behavior

### DIFF
--- a/lib/kind/maybe.rb
+++ b/lib/kind/maybe.rb
@@ -71,7 +71,7 @@ module Kind
       def try(method_name = Undefined, &block)
         Kind.of.Symbol(method_name) if Undefined != method_name
 
-        nil
+        NONE_WITH_NIL_VALUE
       end
 
       private_constant :INVALID_DEFAULT_ARG
@@ -92,11 +92,7 @@ module Kind
       def map(&fn)
         result = fn.call(@value)
 
-        return result if Maybe::None === result
-        return NONE_WITH_NIL_VALUE if result.nil?
-        return NONE_WITH_UNDEFINED_VALUE if Undefined == result
-
-        Some.new(result)
+        resolve(result)
       end
 
       alias_method :then, :map
@@ -106,8 +102,18 @@ module Kind
 
         result = args.empty? ? fn.call(value) : fn.call(*args.unshift(value))
 
-        return result if Maybe::Value.some?(result)
+        resolve(result)
       end
+
+      private
+
+        def resolve(result)
+          return result if Maybe::None === result
+          return NONE_WITH_NIL_VALUE if result.nil?
+          return NONE_WITH_UNDEFINED_VALUE if Undefined == result
+
+          Some.new(result)
+        end
     end
 
     def self.new(value)

--- a/lib/kind/version.rb
+++ b/lib/kind/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Kind
-  VERSION = '2.3.0'
+  VERSION = '3.0.0'
 end

--- a/test/kind/maybe_test.rb
+++ b/test/kind/maybe_test.rb
@@ -184,7 +184,7 @@ class Kind::MaybeTest < Minitest::Test
     assert_equal(-2, result3)
   end
 
-  def test_try_method
+  def test_the_try_method_without_bang
     assert_raises_with_message(Kind::Error, '"upcase" expected to be a kind of Symbol') do
       Kind::Maybe['foo'].try('upcase')
     end
@@ -201,10 +201,12 @@ class Kind::MaybeTest < Minitest::Test
 
     hash = {a: 1}
 
+    assert_nil(Kind::Maybe[hash].try(:upcase).value)
     assert_nil(Kind::Maybe[hash].try(:[], :b).value)
     assert_equal(1, Kind::Maybe[hash].try(:[], :a).value)
     assert_equal(0, Kind::Maybe[hash].try(:fetch, :b, 0).value)
 
+    assert_instance_of(Kind::Maybe::None, Kind::Maybe[hash].try(:upcase))
     assert_instance_of(Kind::Maybe::None, Kind::Maybe[hash].try(:[], :b))
     assert_instance_of(Kind::Maybe::Some,Kind::Maybe[hash].try(:[], :a))
     assert_instance_of(Kind::Maybe::Some, Kind::Maybe[hash].try(:fetch, :b, 0))
@@ -224,6 +226,50 @@ class Kind::MaybeTest < Minitest::Test
 
     assert_instance_of(Kind::Maybe::None, Kind::Maybe[Kind::Undefined].try(:upcase))
     assert_instance_of(Kind::Maybe::None, Kind::Maybe[Kind::Undefined].try { |value| value.upcase })
+  end
+
+  def test_the_try_method_with_bang
+    assert_raises_with_message(Kind::Error, '"upcase" expected to be a kind of Symbol') do
+      Kind::Maybe['foo'].try!('upcase')
+    end
+
+    # ---
+
+    assert_equal('FOO', Kind::Maybe['foo'].try!(:upcase).value)
+    assert_equal('FOO', Kind::Maybe['foo'].try! { |value| value.upcase }.value)
+
+    assert_instance_of(Kind::Maybe::Some, Kind::Maybe['foo'].try!(:upcase))
+    assert_instance_of(Kind::Maybe::Some, Kind::Maybe['foo'].try! { |value| value.upcase })
+
+    # -
+
+    hash = {a: 1}
+
+    assert_raises(NoMethodError) { Kind::Maybe[hash].try!(:upcase) }
+
+    assert_nil(Kind::Maybe[hash].try!(:[], :b).value)
+    assert_equal(1, Kind::Maybe[hash].try!(:[], :a).value)
+    assert_equal(0, Kind::Maybe[hash].try!(:fetch, :b, 0).value)
+
+    assert_instance_of(Kind::Maybe::None, Kind::Maybe[hash].try!(:[], :b))
+    assert_instance_of(Kind::Maybe::Some,Kind::Maybe[hash].try!(:[], :a))
+    assert_instance_of(Kind::Maybe::Some, Kind::Maybe[hash].try!(:fetch, :b, 0))
+
+    # ---
+
+    assert_nil(Kind::Maybe[nil].try!(:upcase).value)
+    assert_nil(Kind::Maybe[nil].try! { |value| value.upcase }.value)
+
+    assert_instance_of(Kind::Maybe::None, Kind::Maybe[nil].try!(:upcase))
+    assert_instance_of(Kind::Maybe::None, Kind::Maybe[nil].try! { |value| value.upcase })
+
+    # -
+
+    assert_nil(Kind::Maybe[Kind::Undefined].try!(:upcase).value)
+    assert_nil(Kind::Maybe[Kind::Undefined].try! { |value| value.upcase }.value)
+
+    assert_instance_of(Kind::Maybe::None, Kind::Maybe[Kind::Undefined].try!(:upcase))
+    assert_instance_of(Kind::Maybe::None, Kind::Maybe[Kind::Undefined].try! { |value| value.upcase })
   end
 
   def test_that_optional_is_an_maybe_alias

--- a/test/kind/maybe_test.rb
+++ b/test/kind/maybe_test.rb
@@ -185,21 +185,45 @@ class Kind::MaybeTest < Minitest::Test
   end
 
   def test_try_method
-    assert_equal('FOO', Kind::Maybe['foo'].try(:upcase))
-    assert_equal('FOO', Kind::Maybe['foo'].try { |value| value.upcase })
-
-    assert_nil(Kind::Maybe[nil].try(:upcase))
-    assert_nil(Kind::Maybe[nil].try { |value| value.upcase })
-
-    assert_nil(Kind::Maybe[Kind::Undefined].try(:upcase))
-    assert_nil(Kind::Maybe[Kind::Undefined].try { |value| value.upcase })
-
-    assert_equal(0, Kind::Maybe[{}].try(:fetch, :number, 0))
-    assert_equal('BAR', Kind::Maybe[{bar: 'BAR'}].try(:fetch, :bar))
-
     assert_raises_with_message(Kind::Error, '"upcase" expected to be a kind of Symbol') do
       Kind::Maybe['foo'].try('upcase')
     end
+
+    # ---
+
+    assert_equal('FOO', Kind::Maybe['foo'].try(:upcase).value)
+    assert_equal('FOO', Kind::Maybe['foo'].try { |value| value.upcase }.value)
+
+    assert_instance_of(Kind::Maybe::Some, Kind::Maybe['foo'].try(:upcase))
+    assert_instance_of(Kind::Maybe::Some, Kind::Maybe['foo'].try { |value| value.upcase })
+
+    # -
+
+    hash = {a: 1}
+
+    assert_nil(Kind::Maybe[hash].try(:[], :b).value)
+    assert_equal(1, Kind::Maybe[hash].try(:[], :a).value)
+    assert_equal(0, Kind::Maybe[hash].try(:fetch, :b, 0).value)
+
+    assert_instance_of(Kind::Maybe::None, Kind::Maybe[hash].try(:[], :b))
+    assert_instance_of(Kind::Maybe::Some,Kind::Maybe[hash].try(:[], :a))
+    assert_instance_of(Kind::Maybe::Some, Kind::Maybe[hash].try(:fetch, :b, 0))
+
+    # ---
+
+    assert_nil(Kind::Maybe[nil].try(:upcase).value)
+    assert_nil(Kind::Maybe[nil].try { |value| value.upcase }.value)
+
+    assert_instance_of(Kind::Maybe::None, Kind::Maybe[nil].try(:upcase))
+    assert_instance_of(Kind::Maybe::None, Kind::Maybe[nil].try { |value| value.upcase })
+
+    # -
+
+    assert_nil(Kind::Maybe[Kind::Undefined].try(:upcase).value)
+    assert_nil(Kind::Maybe[Kind::Undefined].try { |value| value.upcase }.value)
+
+    assert_instance_of(Kind::Maybe::None, Kind::Maybe[Kind::Undefined].try(:upcase))
+    assert_instance_of(Kind::Maybe::None, Kind::Maybe[Kind::Undefined].try { |value| value.upcase })
   end
 
   def test_that_optional_is_an_maybe_alias


### PR DESCRIPTION
### Kind::Maybe#try

If you don't want to use `#map/#then` to access the value, you could use the `#try` method to access it. So, if the value wasn't `nil` or `Kind::Undefined`, the some monad will be returned.

```ruby
object = 'foo'

Kind::Maybe[object].try(:upcase).value # "FOO"

Kind::Maybe[{}].try(:fetch, :number, 0).value # 0

Kind::Maybe[{number: 1}].try(:fetch, :number).value # 1

Kind::Maybe[object].try { |value| value.upcase }.value # "FOO"

#############
# Nil value #
#############

object = nil

Kind::Maybe[object].try(:upcase).value # nil

Kind::Maybe[object].try { |value| value.upcase }.value # nil

#########################
# Kind::Undefined value #
#########################

object = Kind::Undefined

Kind::Maybe[object].try(:upcase).value # nil

Kind::Maybe[object].try { |value| value.upcase }.value # nil
```

> **Note:** You can use the `#try` method with `Kind::Optional` objects.

### Kind::Maybe#try!

Has the same behavior of its `#try`, but it will raise an error if the value doesn't respond to the expected method.

```ruby
Kind::Maybe[{}].try(:upcase)  # => #<Kind::Maybe::None:0x0000... @value=nil>

Kind::Maybe[{}].try!(:upcase) # => NoMethodError (undefined method `upcase' for {}:Hash)
```