### PR TITLE
Release v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,54 +28,75 @@
 
 As a creator of Ruby gems, I have a common need that I have to handle in many of my projects: type checking of method arguments.
 
-One of the goals of this project is to do simple type checking like `"some string".is_a?(String)`, but, exposing useful abstractions to do it. e.g: [Kind.of.\<Type\> methods](#verifying-the-kind-of-some-object), [active model validations](#kindvalidator-activemodelvalidations), [maybe monad](#kindmaybe).
+One of the goals of this project is to do simple type checking like `"some string".is_a?(String)`, but, exposing useful abstractions around this. e.g: [Kind.\<Type\> methods](#verifying-the-kind-of-some-object), [active model validations](#kindvalidator-activemodelvalidations), [maybe monad](#kindmaybe).
 
 ## Documentation <!-- omit in toc -->
 
-Version   | Documentation
---------- | -------------
-unreleased| https://github.com/serradura/u-case/blob/main/README.md
-3.1.0     | https://github.com/serradura/u-case/blob/v3.x/README.md
-2.3.0     | https://github.com/serradura/u-case/blob/v2.x/README.md
-1.9.0     | https://github.com/serradura/u-case/blob/v1.x/README.md
+Version    | Documentation
+---------- | -------------
+unreleased | https://github.com/serradura/u-case/blob/main/README.md
+4.0.0      | https://github.com/serradura/u-case/blob/v4.x/README.md
+3.1.0      | https://github.com/serradura/u-case/blob/v3.x/README.md
+2.3.0      | https://github.com/serradura/u-case/blob/v2.x/README.md
+1.9.0      | https://github.com/serradura/u-case/blob/v1.x/README.md
 
 ## Table of Contents <!-- omit in toc -->
 - [Compatibility](#compatibility)
 - [Installation](#installation)
 - [Usage](#usage)
-  - [Kind.of.\<Type\>() - Verifying the kind of some object](#kindoftype---verifying-the-kind-of-some-object)
-    - [Method aliases to perform a strict validation](#method-aliases-to-perform-a-strict-validation)
-  - [Kind.of.\<Type\>.or_nil()](#kindoftypeor_nil)
-  - [Kind.of.\<Type\>.instance?()](#kindoftypeinstance)
-  - [Kind.is.\<Type\>() - Verifying if some class/module is the expected kind.](#kindistype---verifying-if-some-classmodule-is-the-expected-kind)
-  - [How to create a new type checker?](#how-to-create-a-new-type-checker)
-    - [Creating/Verifiyng type checkers dynamically](#creatingverifiyng-type-checkers-dynamically)
-    - [Registering new (custom) type checker](#registering-new-custom-type-checker)
-      - [What happens if a custom type checker has a namespace?](#what-happens-if-a-custom-type-checker-has-a-namespace)
-- [Type checkers](#type-checkers)
-  - [Classes' type checkers](#classes-type-checkers)
-  - [Modules' type checkers](#modules-type-checkers)
-  - [Specials' type checkers](#specials-type-checkers)
-- [Kind::Validator (ActiveModel::Validations)](#kindvalidator-activemodelvalidations)
-  - [Usage](#usage-1)
-    - [Defining the default validation strategy](#defining-the-default-validation-strategy)
-    - [Using the `allow_nil` and `strict` options](#using-the-allow_nil-and-strict-options)
+  - [Kind.\<Type\>[]](#kindtype)
+  - [Kind::\<Type\>.===()](#kindtype-1)
+  - [Kind::\<Type\>.value?()](#kindtypevalue)
+  - [Kind::\<Type\>.or_nil()](#kindtypeor_nil)
+  - [Kind::\<Type\>.or_undefined()](#kindtypeor_undefined)
+  - [Kind::\<Type\>.or()](#kindtypeor)
+  - [Kind::\<Type\>.value()](#kindtypevalue-1)
+  - [Kind::\<Type\>?](#kindtype-2)
+  - [Kind::{Array,Hash,String,Set}.value_or_empty()](#kindarrayhashstringsetvalue_or_empty)
+  - [List of all type checkers (Kind::<Type>)](#list-of-all-type-checkers-kindtype)
+    - [Core](#core)
+    - [Stdlib](#stdlib)
+    - [Custom](#custom)
+  - [Creating type checkers](#creating-type-checkers)
+    - [Dynamic creation](#dynamic-creation)
+      - [Using a class or a module](#using-a-class-or-a-module)
+      - [Using an object which responds to ===](#using-an-object-which-responds-to-)
+    - [Kind::<Type> module](#kindtype-module)
+  - [Utility methods](#utility-methods)
+    - [Kind.of_class?()](#kindof_class)
+    - [Kind.of_module?()](#kindof_module)
+    - [Kind.of_module_or_class()](#kindof_module_or_class)
+    - [Kind.respond_to()](#kindrespond_to)
+    - [Kind.of()](#kindof)
+    - [Kind.of?()](#kindof-1)
+    - [Kind.value()](#kindvalue)
+    - [Kind.is()](#kindis)
+  - [Utility modules](#utility-modules)
+    - [Kind::Try](#kindtry)
+    - [Kind::Dig](#kinddig)
+    - [Kind::Presence](#kindpresence)
 - [Kind::Undefined](#kindundefined)
-  - [Kind.of.\<Type\>.or_undefined()](#kindoftypeor_undefined)
 - [Kind::Maybe](#kindmaybe)
     - [Replacing blocks by lambdas](#replacing-blocks-by-lambdas)
   - [Kind::Maybe[], Kind::Maybe.wrap() and Kind::Maybe#then method aliases](#kindmaybe-kindmaybewrap-and-kindmaybethen-method-aliases)
     - [Replacing blocks by lambdas](#replacing-blocks-by-lambdas-1)
   - [Kind::None() and Kind::Some()](#kindnone-and-kindsome)
-  - [Kind.of.Maybe()](#kindofmaybe)
   - [Kind::Optional](#kindoptional)
     - [Replacing blocks by lambdas](#replacing-blocks-by-lambdas-2)
-  - [Kind.of.\<Type\>.as_optional](#kindoftypeas_optional)
   - [Kind::Maybe(<Type>)](#kindmaybetype)
+    - [Real world examples](#real-world-examples)
+  - [Error handling](#error-handling)
+    - [Kind::Maybe.wrap {}](#kindmaybewrap-)
+    - [Kind::Maybe.map! or Kind::Maybe.then!](#kindmaybemap-or-kindmaybethen)
   - [Kind::Maybe#try](#kindmaybetry)
   - [Kind::Maybe#try!](#kindmaybetry-1)
   - [Kind::Maybe#dig](#kindmaybedig)
+  - [Kind::Maybe#check](#kindmaybecheck)
 - [Kind::Empty](#kindempty)
+- [Kind::Validator (ActiveModel::Validations)](#kindvalidator-activemodelvalidations)
+  - [Usage](#usage-1)
+    - [Defining the default validation strategy](#defining-the-default-validation-strategy)
+    - [Using the `allow_nil` and `strict` options](#using-the-allow_nil-and-strict-options)
 - [Similar Projects](#similar-projects)
 - [Development](#development)
 - [Contributing](#contributing)
@@ -87,6 +108,7 @@ unreleased| https://github.com/serradura/u-case/blob/main/README.md
 | u-case         | branch  | ruby     |  activemodel   |
 | -------------- | ------- | -------- | -------------- |
 | unreleased     | main    | >= 2.2.0 | >= 3.2, <= 6.1 |
+| 4.0.0          | v4.x    | >= 2.2.0 | >= 3.2, <= 6.1 |
 | 3.1.0          | v3.x    | >= 2.2.0 | >= 3.2, <= 6.1 |
 | 2.3.0          | v2.x    | >= 2.2.0 | >= 3.2, <= 6.0 |
 | 1.9.0          | v1.x    | >= 2.2.0 | >= 3.2, <= 6.0 |
@@ -109,7 +131,7 @@ Or install it yourself as:
 
     $ gem install kind
 
-[⬆️ Back to Top](#table-of-contents-)
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
 
 ## Usage
 
@@ -117,7 +139,7 @@ With this gem you can add some kind of type checking at runtime. e.g:
 
 ```ruby
 def sum(a, b)
-  Kind.of.Numeric(a) + Kind.of.Numeric(b)
+  Kind::Numeric[a] + Kind::Numeric[b]
 end
 
 sum(1, 1)   # 2
@@ -125,155 +147,483 @@ sum(1, 1)   # 2
 sum('1', 1) # Kind::Error ("\"1\" expected to be a kind of Numeric")
 ```
 
-### Kind.of.\<Type\>() - Verifying the kind of some object
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
 
-By default, basic verifications are strict. So, when you perform `Kind.of.Hash(value)`, if the given value was a Hash, the value itself will be returned, but if it isn't the right type, an error will be raised.
+### Kind.\<Type\>[]
 
-```ruby
-Kind.of.Hash(nil)  # **raise Kind::Error, "nil expected to be a kind of Hash"**
-Kind.of.Hash('')   # raise Kind::Error, "'' expected to be a kind of Hash"
-Kind.of.Hash(a: 1) # {a: 1}
-
-# ---
-
-Kind.of.Boolean(nil)   # raise Kind::Error, "nil expected to be a kind of Boolean"
-Kind.of.Boolean(true)  # true
-Kind.of.Boolean(false) # false
-```
-
-> **Note:** `Kind.of.<Type>` supports the to_proc protocol.
-> And it will perform a strict validation as expected.
+By default, basic verifications are strict. So, when you perform `Kind::Hash[value]` the given value will be returned if it was a Hash, but if not, an error will be raised.
 
 ```ruby
-collection = [ {number: 1}, 'number 2', {number: 3}, :number_4 ]
-
-collection.map(&Kind.of.Hash) # Kind::Error ("number 2" expected to be a kind of Hash)
+Kind::Hash[nil]  # Kind::Error (nil expected to be a kind of Hash)
+Kind::Hash['']   # Kind::Error ("" expected to be a kind of Hash)
+Kind::Hash[a: 1] # {a: 1}
 ```
 
-When the verified value is nil, it is possible to define a default value with the same type to be returned.
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
+
+### Kind::\<Type\>.===()
+
+Use this method to verify if the given object has the expected type.
 
 ```ruby
-value = nil
-
-Kind.of.Hash(value, or: {})    # {}
-
-# ---
-
-Kind.of.Boolean(nil, or: true) # true
+Kind::Enumerable === {} # true
+Kind::Enumerable === '' # false
 ```
 
-> **Note:** As an alternative syntax, you can use the `Kind::Of` instead of the `Kind.of` method. e.g: `Kind::Of::Hash('')`
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
 
-#### Method aliases to perform a strict validation
+### Kind::\<Type\>.value?()
+
+This method works like `.===`, but the difference is what happens when you invoke it without arguments.
 
 ```ruby
-Kind.of.Hash[nil]  # raise Kind::Error, "nil expected to be a kind of Hash"
-Kind.of.Hash['']   # raise Kind::Error, "'' expected to be a kind of Hash"
-Kind.of.Hash[a: 1] # {a: 1}
-Kind.of.Hash['', or: {}] # {}
+# Example of calling `.value?` with an argument:
 
-# or
-
-Kind.of.Hash.instance(nil)  # raise Kind::Error, "nil expected to be a kind of Hash"
-Kind.of.Hash.instance('')   # raise Kind::Error, "'' expected to be a kind of Hash"
-Kind.of.Hash.instance(a: 1) # {a: 1}
-Kind.of.Hash.instance('', or: {}) # {}
+Kind::Enumerable.value?({}) # true
+Kind::Enumerable.value?('') # false
 ```
 
-### Kind.of.\<Type\>.or_nil()
+When `.value?` is called without an argument, it will return a lambda which will know how to perform the kind verification.
+
+```ruby
+collection = [ {number: 1}, 'number 2', {number: 3}, :number_4, [:number, 5] ]
+
+collection.select(&Kind::Enumerable.value?) # [{:number=>1}, {:number=>3}, [:number, 5]]
+```
+
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
+
+### Kind::\<Type\>.or_nil()
 
 But if you don't need a strict type verification, use the `.or_nil` method.
 
 ```ruby
-Kind.of.Hash.or_nil('')     # nil
-Kind.of.Hash.or_nil({a: 1}) # {a: 1}
-
-# ---
-
-Kind.of.Boolean.or_nil('')   # nil
-Kind.of.Boolean.or_nil(true) # true
+Kind::Hash.or_nil('')     # nil
+Kind::Hash.or_nil({a: 1}) # {a: 1}
 ```
 
-### Kind.of.\<Type\>.instance?()
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
 
-Use the method `.instance?` to verify if the given object has the expected type.
+### Kind::\<Type\>.or_undefined()
+
+This method works like `.or_nil`, but it will return a [`Kind::Undefined`](#kindundefined) instead of `nil`.
 
 ```ruby
-Kind.of.Hash.instance?({})                                # true
-Kind.of.Hash.instance?({}, HashWithIndifferentAccess.new) # true
-
-Kind.of.Hash.instance?('')     # false
-Kind.of.Hash.instance?({}, '') # false
-
-# ---
-
-Kind.of.Boolean.instance?(true)             # true
-Kind.of.Boolean.instance?(true, false)      # true
-
-Kind.of.Boolean.instance?(nil)              # false
-Kind.of.Boolean.instance?(false, true, nil) # false
+Kind::Hash.or_undefined('')     # Kind::Undefined
+Kind::Hash.or_undefined({a: 1}) # {a: 1}
 ```
 
-> **Note:** When `.instance?` is called without an argument,
-> it will return a lambda which will perform the kind verification.
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
+
+### Kind::\<Type\>.or()
+
+This method can return a fallback if the given value isn't an instance of the expected kind.
 
 ```ruby
-collection = [ {number: 1}, 'number 2', {number: 3}, :number_4 ]
-
-collection
-  .select(&Kind.of.Hash.instance?) # [{:number=>1}, {:number=>3}]
+Kind::Hash.or({}, [])      # {}
+Kind::Hash.or(nil, [])     # nil
+Kind::Hash.or(nil, {a: 1}) # {a: 1}
 ```
 
-> **Note:** You can use a different syntax to perform an instance verification.
-> To do this, use Kind.of.\<Type\>?()
+If it doesn't receive a second argument (the value), it will return a callable that knows how to expose an instance of the expected type or a fallback if the given value is wrong.
 
 ```ruby
-Kind.of.Hash?({})                                # true
-Kind.of.Hash?({}, HashWithIndifferentAccess.new) # true
+collection = [ {number: 1}, 'number 2', {number: 3}, :number_4, [:number, 5] ]
 
-Kind.of.Hash?('')     # false
-Kind.of.Hash?({}, '') # false
-
-# ---
-
-Kind.of.Boolean?(true)        # true
-Kind.of.Boolean?(false, true) # true
-
-Kind.of.Boolean?(nil)              # false
-Kind.of.Boolean?(false, true, nil) # false
-
-# ---
-
-collection = [ {number: 1}, 'number 2', {number: 3}, :number_4 ]
-
-collection.select(&Kind.of.Hash?) # [{:number=>1}, {:number=>3}]
+collection.map(&Kind::Hash.or({}))  # [{:number=>1}, {}, {:number=>3}, {}, {}]
+collection.map(&Kind::Hash.or(nil)) # [{:number=>1}, nil, {:number=>3}, nil, nil]
 ```
 
-### Kind.is.\<Type\>() - Verifying if some class/module is the expected kind.
+An error will be raised if the fallback didn't have the expected kind or if not `nil` / `Kind::Undefined`.
+
+```ruby
+collection = [ {number: 1}, 'number 2', {number: 3}, :number_4, [:number, 5] ]
+
+collection.map(&Kind::Hash.or(:foo)) # Kind::Error (:foo expected to be a kind of Hash)
+```
+
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
+
+### Kind::\<Type\>.value()
+
+This method ensures that you will have a value of the expected kind. But, in the case of the given value be invalid, this method will require a default value (with the expected kind) to be returned.
+```ruby
+Kind::String.value(1, default: '')   # ""
+
+Kind::String.value('1', default: '') # "1"
+
+Kind::String.value('1', default: 1)  # Kind::Error (1 expected to be a kind of String)
+```
+
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
+
+### Kind::\<Type\>?
+
+There is a second way to do a type verification and know if one or multiple values has the expected type. You can use the predicate kind methods (`Kind::Hash?`). e.g:
+
+```ruby
+# Verifying one value
+Kind::Enumerable?({}) # true
+
+# Verifying multiple values
+Kind::Enumerable?({}, [], Set.new) # true
+```
+
+Like the `Kind::<Type>.value?` method, if the `Kind::<Type>?` doesn't receive an argument, it will return a lambda which will know how to perform the kind verification.
+
+```ruby
+collection = [ {number: 1}, 'number 2', {number: 3}, :number_4, [:number, 5] ]
+
+collection.select(&Kind::Enumerable?) # [{:number=>1}, {:number=>3}, [:number, 5]]
+```
+
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
+
+### Kind::{Array,Hash,String,Set}.value_or_empty()
+
+This method is available for some type checkers (`Kind::Array`, `Kind::Hash`, `Kind::String`, `Kind::Set`), and it will return an empty frozen value if the given one hasn't the expected kind.
+```ruby
+Kind::Array.value_or_empty({})         # []
+Kind::Array.value_or_empty({}).frozen? # true
+```
+
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
+
+### List of all type checkers (Kind::<Type>)
+
+#### Core
+
+* `Kind::Array`
+* `Kind::Class`
+* `Kind::Comparable`
+* `Kind::Enumerable`
+* `Kind::Enumerator`
+* `Kind::File`
+* `Kind::Float`
+* `Kind::Hash`
+* `Kind::Integer`
+* `Kind::IO`
+* `Kind::Method`
+* `Kind::Module`
+* `Kind::Numeric`
+* `Kind::Proc`
+* `Kind::Queue`
+* `Kind::Range`
+* `Kind::Regexp`
+* `Kind::String`
+* `Kind::Struct`
+* `Kind::Symbol`
+* `Kind::Time`
+
+#### Stdlib
+
+* `Kind::OpenStruct`
+* `Kind::Set`
+
+#### Custom
+
+* `Kind::Boolean`
+* `Kind::Callable`
+* `Kind::Lambda`
+
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
+
+### Creating type checkers
+
+There are two ways to do this, you can create type checkers dynamically or defining a module.
+
+#### Dynamic creation
+
+##### Using a class or a module
+
+```ruby
+class User
+end
+
+user = User.new
+
+kind_of_user = Kind::Of(User)
+
+# kind_of_user.name
+# kind_of_user.kind
+# The type checker can return its kind and its name
+kind_of_user.name # "User"
+kind_of_user.kind # User
+
+# kind_of_user.===
+# Can check if a given value is an instance of its kind.
+kind_of_user === 0        # false
+kind_of_user === User.new # true
+
+# kind_of_user.value?(value)
+# Can check if a given value is an instance of its kind.
+kind_of_user.value?('')       # false
+kind_of_user.value?(User.new) # true
+
+# If it doesn't receive an argument, a lambda will be returned and it will know how to do the type verification.
+[0, User.new].select?(&kind_of_user.value?) # [#<User:0x0000.... >]
+
+# kind_of_user.or_nil(value)
+# Can return nil if the given value isn't an instance of its kind
+kind_of_user.or_nil({})       # nil
+kind_of_user.or_nil(User.new) # #<User:0x0000.... >
+
+# kind_of_user.or_undefined(value)
+# Can return Kind::Undefined if the given value isn't an instance of its kind
+kind_of_user.or_undefined([])       # Kind::Undefined
+kind_of_user.or_undefined(User.new) # #<User:0x0000.... >
+
+# kind_of_user.or(fallback, value)
+# Can return a fallback if the given value isn't an instance of its kind
+kind_of_user.or(nil, 0)        # nil
+kind_of_user.or(nil, User.new) # #<User:0x0000.... >
+
+# If it doesn't receive a second argument (the value), it will return a callable that knows how to expose an instance of the expected type or a fallback if the given value was wrong.
+[1, User.new].map(&kind_of_user.or(nil)) # [nil, #<User:0x0000.... >]
+
+# An error will be raised if the fallback didn't have the expected kind or if not nil / Kind::Undefined.
+[0, User.new].map(&kind_of_user.or(:foo)) # Kind::Error (:foo expected to be a kind of User)
+
+# kind_of_user[value]
+# Will raise Kind::Error if the given value isn't an instance of the expected kind
+kind_of_user[:foo]     # Kind::Error (:foo expected to be a kind of User)
+kind_of_user[User.new] # #<User:0x0000.... >
+
+# kind_of_user.value(arg, default:)
+# This method ensures that you will have a value of the expected kind. But, in the case of the given value be invalid, this method will require a default value (with the expected kind) to be returned.
+kind_of_user.value(User.new, default: User.new) # #<User:0x0000...>
+
+kind_of_user.value('1', default: User.new)      # #<User:0x0000...>
+
+kind_of_user.value('1', default: 1)  # Kind::Error (1 expected to be a kind of User)
+```
+
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
+
+##### Using an object which responds to ===
+
+Example using a lambda (an object which responds to .===) and a hash with the kind name.
+
+```ruby
+PositiveInteger = Kind::Of(
+  -> value { value.kind_of?(Integer) && value > 0 },
+  name: 'PositiveInteger'
+)
+
+# PositiveInteger.name
+# PositiveInteger.kind
+# The type checker can return its kind and its name
+PositiveInteger.name # "PositiveInteger"
+PositiveInteger.kind # #<Proc:0x0000.... >
+
+# PositiveInteger.===
+# Can check if a given value is an instance of its kind.
+PositiveInteger === 1 # true
+PositiveInteger === 0 # false
+
+# PositiveInteger.value?(value)
+# Can check if a given value is an instance of its kind.
+PositiveInteger.value?(1)  # true
+PositiveInteger.value?(-1) # false
+
+# If it doesn't receive an argument, a lambda will be returned and it will know how to do the type verification.
+[1, 2, 0, 3, -1].select?(&PositiveInteger.value?) # [1, 2, 3]
+
+# PositiveInteger.or_nil(value)
+# Can return nil if the given value isn't an instance of its kind
+PositiveInteger.or_nil(1) # 1
+PositiveInteger.or_nil(0) # nil
+
+# PositiveInteger.or_undefined(value)
+# Can return Kind::Undefined if the given value isn't an instance of its kind
+PositiveInteger.or_undefined(2)  # 2
+PositiveInteger.or_undefined(-1) # Kind::Undefined
+
+# PositiveInteger.or(fallback, value)
+# Can return a fallback if the given value isn't an instance of its kind
+PositiveInteger.or(nil, 1) # 1
+PositiveInteger.or(nil, 0) # nil
+
+# If it doesn't receive a second argument (the value), it will return a callable that knows how to expose an instance of the expected type or a fallback if the given value was wrong.
+[1, 2, 0, 3, -1].map(&PositiveInteger.or(1))   # [1, 2, 1, 3, 1]
+[1, 2, 0, 3, -1].map(&PositiveInteger.or(nil)) # [1, 2, nil, 3, nil]
+
+# An error will be raised if the fallback didn't have the expected kind or if not nil / Kind::Undefined.
+[1, 2, 0, 3, -1].map(&PositiveInteger.or(:foo)) # Kind::Error (:foo expected to be a kind of PositiveInteger)
+
+# PositiveInteger[value]
+# Will raise Kind::Error if the given value isn't an instance of the expected kind
+PositiveInteger[1]    # 1
+PositiveInteger[:foo] # Kind::Error (:foo expected to be a kind of PositiveInteger)
+
+# PositiveInteger.value(arg, default:)
+# This method ensures that you will have a value of the expected kind. But, in the case of the given value be invalid, this method will require a default value (with the expected kind) to be returned.
+PositiveInteger.value(2, default: 1)   # 2
+
+PositiveInteger.value('1', default: 1) # 1
+
+PositiveInteger.value('1', default: 0) # Kind::Error (0 expected to be a kind of PositiveInteger)
+```
+
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
+
+#### Kind::<Type> module
+
+The idea here is to create a type checker inside of the `Kind` namespace, so to do this, you will only need to use pure Ruby. e.g:
+
+```ruby
+class User
+end
+
+module Kind
+  module User
+    extend self, TypeChecker
+
+    # Define the expected kind of this type checker.
+    def kind; ::User; end
+  end
+
+  # This how the Kind::<Type>? methods are defined.
+  def self.User?(*values)
+    KIND.of?(::User, values)
+  end
+end
+
+# Doing this you will have the same methods of a standard type checker (like: `Kind::Symbol`).
+
+user = User.new
+
+Kind::User[user] # #<User:0x0000...>
+Kind::User[{}]   # Kind::Error ({} expected to be a kind of User)
+
+Kind::User?(user) # true
+Kind::User?({})   # false
+```
+
+The advantages of this approach are:
+
+1. You will have a singleton (a unique instance) to be used, so the garbage collector will work less.
+2. You can define additional methods to be used with this kind.
+
+The disadvantage is:
+
+1. You could overwrite some standard type checker or constant. I believe that this will be hard to happen, but must be your concern if you decide to use this kind of approach.
+
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
+
+### Utility methods
+
+#### Kind.of_class?()
+
+This method verify if a given value is a `Class`.
+
+```ruby
+Kind.of_class?(Hash)       # true
+Kind.of_class?(Enumerable) # false
+Kind.of_class?(1)          # false
+```
+
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
+
+#### Kind.of_module?()
+
+This method verify if a given value is a `Module`.
+
+```ruby
+Kind.of_module?(Hash)       # false
+Kind.of_module?(Enumerable) # true
+Kind.of_module?(1)          # false
+```
+
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
+
+#### Kind.of_module_or_class()
+
+This method return the given value if it is a module or a class. If not, a `Kind::Error` will be raised.
+
+```ruby
+Kind.of_module_or_class(String) # String
+Kind.of_module_or_class(1)      # Kind::Error (1 expected to be a kind of Module/Class)
+```
+
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
+
+#### Kind.respond_to()
+
+this method returns the given object if it responds to all of the method names. But if the object does not respond to some of the expected methods, an error will be raised.
+  ```ruby
+  Kind.respond_to('', :upcase)         # ""
+  Kind.respond_to('', :upcase, :strip) # ""
+
+  Kind.respond_to(1, :upcase)        # expected 1 to respond to :upcase
+  Kind.respond_to(2, :to_s, :upcase) # expected 2 to respond to :upcase
+  ```
+
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
+
+#### Kind.of()
+
+There is a second way to do a strict type verification, you can use the `Kind.of()` method to do this. It receives the kind as the first argument and the value to be checked as the second one.
+```ruby
+Kind.of(Hash, {}) # {}
+Kind.of(Hash, []) # Kind::Error ([] expected to be a kind of Hash)
+```
+
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
+
+#### Kind.of?()
+
+This method can be used to check if one or multiple values have the expected kind.
+
+```ruby
+# Checking one value
+Kind.of?(Array, []) # true
+Kind.of?(Array, {}) # false
+
+# Checking multiple values
+Kind.of?(Enumerable, [], {}) # true
+Kind.of?(Hash, {}, {})       # true
+Kind.of?(Array, [], {})      # false
+```
+
+If the method receives only the first argument (the kind) a lambda will be returned and it will know how to do the type verification.
+
+```ruby
+[1, '2', 3].select(&Kind.of?(Numeric)) # [1, 3]
+```
+
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
+
+#### Kind.value()
+
+This method ensures that you will have a value of the expected kind. But, in the case of the given value be invalid, this method will require a default value (with the expected kind) to be returned.
+```ruby
+Kind.value(String, '1', default: '') # "1"
+
+Kind.value(String, 1, default: '')   # ""
+
+Kind.value(String, 1, default: 2)    # Kind::Error (2 expected to be a kind of String)
+```
+
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
+
+#### Kind.is()
 
 You can use `Kind.is` to verify if some class has the expected type as its ancestor.
 
 ```ruby
-Kind.is.Hash(String) # false
+Kind.is(Hash, String) # false
 
-Kind.is.Hash(Hash)   # true
+Kind.is(Hash, Hash)   # true
 
-Kind.is.Hash(ActiveSupport::HashWithIndifferentAccess) # true
+Kind.is(Enumerable, Hash) # true
 ```
 
-And just for convenience, you can use the method `Kind.of.*.class?` to verify if the given class has the expected type as its ancestor.
-
-```ruby
-Kind.of.Hash.class?(Hash) # true
-
-Kind.of.Hash.class?(ActiveSupport::HashWithIndifferentAccess) # true
-```
-
-> **Note:** The `Kind.is` could check the inheritance of Classes/Modules.
+The `Kind.is` also could check the inheritance of Classes/Modules.
 
 ```ruby
 #
-# Verifying if the attribute value is the class or a subclass.
+# Verifying if a class is or inherits from the expected class.
 #
 class Human; end
 class Person < Human; end
@@ -286,7 +636,7 @@ Kind.is(Human, Person) # true
 Kind.is(Human, Struct) # false
 
 #
-# Verifying if the attribute value is the module or if it is a class that includes the module
+# Verifying if the classes included a module.
 #
 module Human; end
 class Person; include Human; end
@@ -299,7 +649,7 @@ Kind.is(Human, Person) # true
 Kind.is(Human, Struct) # false
 
 #
-# Verifying if the attribute value is the module or if it is a module that extends the module
+# Verifying if a class is or inherits from the expected module.
 #
 module Human; end
 module Person; extend Human; end
@@ -312,211 +662,726 @@ Kind.is(Human, Person) # true
 Kind.is(Human, Struct) # false
 ```
 
-[⬆️ Back to Top](#table-of-contents-)
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
 
-### How to create a new type checker?
+### Utility modules
 
-There are two ways to do this, you can create type checkers dynamically or register new ones.
+#### Kind::Try
 
-#### Creating/Verifiyng type checkers dynamically
+The method `.call` of this module invokes a public method with or without arguments like `public_send` does, except that if the receiver does not respond to it the call returns `nil` rather than raising an exception.
 
 ```ruby
-class User
-end
+Kind::Try.(' foo ', :strip)        # "foo"
+Kind::Try.({a: 1}, :[], :a)        # 1
+Kind::Try.({a: 1}, :[], :b)        # nil
+Kind::Try.({a: 1}, :fetch, :b, 2)  # 2
 
-user = User.new
+Kind::Try.(:symbol, :strip)        # nil
+Kind::Try.(:symbol, :fetch, :b, 2) # nil
 
-# ------------------------ #
-# Verifiyng the value kind #
-# ------------------------ #
-
-Kind.of(User, user) # <User ...>
-Kind.of(User, {})   # Kind::Error ({} expected to be a kind of User)
-
-Kind.of(Hash, {})   # {}
-Kind.of(Hash, user) # Kind::Error (<User ...> expected to be a kind of Hash)
-
-# ----------------------------------------- #
-# Verifiyng if the value is a kind instance #
-# ----------------------------------------- #
-
-Kind.of?(Numeric, 1)      # true
-Kind.of?(Numeric, 1, 2.0) # true
-
-Kind.of?(Numeric, '1')      # false
-Kind.of?(Numeric, 1, '2.0') # false
-
-# Note: Kind.of?(Type) without arguments will return a
-#       lambda that will perform an instance verification
-#
-[1, '2', 3.0, '4']
-  .select(&Kind.of?(Numeric)) # [1, 3.0]
-
-# ---------------------------------- #
-# Creating type checkers dynamically #
-# ---------------------------------- #
-
-kind_of_user = Kind.of(User)
-
-kind_of_user.or_nil({}) # nil
-
-kind_of_user.instance?({})   # false
-kind_of_user.instance?(User) # true
-
-kind_of_user.class?(Hash)  # false
-kind_of_user.class?(User)  # true
-
-# ------------------------------------ #
-# Using methods which returns a lambda #
-# ------------------------------------ #
-collection = [User.new, User.new, 0, {} nil, User.new]
-
-collection.select(&Kind.of(User).instance?).size == 3 # true
-
-collection.map(&Kind.of(User).as_optional).select(&:some?).size == 3 # true
-
-# Creating type checkers dynamically is cheap
-# because a singleton object is created to be available for use.
-
-kind_of_user.object_id == Kind.of(User).object_id # true
-
-# --------------------------------------------- #
-# Kind.is() can be used to check a class/module #
-# --------------------------------------------- #
-
-class AdminUser < User
-end
-
-Kind.is(User, AdminUser) # true
+# It raises an exception if the method name isn't a string or a symbol
+Kind::Try.({a: 1}, 1, :a) # TypeError (1 is not a symbol nor a string)
 ```
 
-#### Registering new (custom) type checker
-
-Use `Kind::Types.add()`. e.g:
+This module has the method `[]` that knows how to create a lambda that will know how to perform the `try` strategy.
 
 ```ruby
-class User
-end
+results =
+  [
+    {},
+    {name: 'Foo Bar'},
+    {name: 'Rodrigo Serradura'},
+  ].map(&Kind::Try[:fetch, :name, 'John Doe'])
 
-# You can define it at the end of the file class/module where class/module was declared.
-
-Kind::Types.add(User)
-
-# Or, you can add the type checker within the class definition.
-
-class User
-  Kind::Types.add(self)
-end
-
-# --------------- #
-# Usage examples: #
-# --------------- #
-
-Kind.of.User(User.new)  # #<User:0x0000...>
-
-Kind.of.User({})        # Kind::Error ({} expected to be a kind of User)
-
-Kind.of.User.or_nil({}) # nil
-
-Kind.of.User.instance?({})   # false
-Kind.of.User.instance?(User) # true
-
-Kind.of.User.class?(Hash)  # false
-Kind.of.User.class?(User)  # true
+p results # ["John Doe", "Foo Bar", "Rodrigo Serradura"]
 ```
 
-[⬆️ Back to Top](#table-of-contents-)
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
 
-##### What happens if a custom type checker has a namespace?
+#### Kind::Dig
 
-The type checker will preserve the namespace. ;)
+The method `.call` of this module has the same behavior of Ruby dig methods ([Hash](https://ruby-doc.org/core-2.3.0/Hash.html#method-i-dig), [Array](https://ruby-doc.org/core-2.3.0/Array.html#method-i-dig), [Struct](https://ruby-doc.org/core-2.3.0/Struct.html#method-i-dig), [OpenStruct](https://ruby-doc.org/stdlib-2.3.0/libdoc/ostruct/rdoc/OpenStruct.html#method-i-dig)), but it will not raise an error if some step can't be digged.
 
 ```ruby
-module Account
-  class User
-    Kind::Types.add(self)
+s = Struct.new(:a, :b).new(101, 102)
+o = OpenStruct.new(c: 103, d: 104)
+d = { struct: s, ostruct: o, data: [s, o]}
+
+Kind::Dig.(s, [:a])            # 101
+Kind::Dig.(o, [:c])            # 103
+
+Kind::Dig.(d, [:struct, :b])   # 102
+Kind::Dig.(d, [:data, 0, :b])  # 102
+Kind::Dig.(d, [:data, 0, 'b']) # 102
+
+Kind::Dig.(d, [:ostruct, :d])  # 104
+Kind::Dig.(d, [:data, 1, :d])  # 104
+Kind::Dig.(d, [:data, 1, 'd']) # 104
+
+Kind::Dig.(d, [:struct, :f])   # nil
+Kind::Dig.(d, [:ostruct, :f])  # nil
+Kind::Dig.(d, [:data, 0, :f])  # nil
+Kind::Dig.(d, [:data, 1, :f])  # nil
+```
+
+Another difference between the `Kind::Dig` and the native Ruby dig, is that it knows how to extract values from regular objects.
+
+```ruby
+class Person
+  attr_reader :name
+
+  def initialize(name)
+    @name = name
   end
 end
 
-module Account
-  class User
-    class Membership
-      Kind::Types.add(self)
-    end
+person = Person.new('Rodrigo')
+
+Kind::Dig.(person, [:name])                         # "Rodrigo"
+
+Kind::Dig.({people: [person]}, [:people, 0, :name]) # "Rodrigo"
+```
+
+This module has the method `[]` that knows how to create a lambda that will know how to perform the `dig` strategy.
+
+```ruby
+results = [
+  { person: {} },
+  { person: { name: 'Foo Bar'} },
+  { person: { name: 'Rodrigo Serradura'} },
+].map(&Kind::Dig[:person, :name])
+
+p results # [nil, "Foo Bar", "Rodrigo Serradura"],
+```
+
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
+
+#### Kind::Presence
+
+The method `.call` of this module returns the given value if it's present otherwise it will return `nil`.
+
+```ruby
+Kind::Presence.(true)         # true
+Kind::Presence.('foo')        # "foo"
+Kind::Presence.([1, 2])       # [1, 2]
+Kind::Presence.({a: 3})       # {a: 3}
+Kind::Presence.(Set.new([4])) # #<Set: {4}>
+
+Kind::Presence.('')       # nil
+Kind::Presence.('   ')    # nil
+Kind::Presence.("\t\n\r") # nil
+Kind::Presence.("\u00a0") # nil
+
+Kind::Presence.([])       # nil
+Kind::Presence.({})       # nil
+Kind::Presence.(Set.new)  # nil
+
+Kind::Presence.(nil)      # nil
+Kind::Presence.(false)    # nil
+
+# nil will be returned if the given object responds to the method blank? and this method result is true.
+MyObject = Struct.new(:is_blank) do
+  def blank?
+    is_blank
   end
 end
 
-Kind.of.Account::User({}) # Kind::Error ({} expected to be a kind of Account::User)
+my_object = MyObject.new
 
-Kind.of.Account::User(Account::User.new)  # #<Account::User:0x0000...>
+my_object.is_blank = true
 
-Kind.of.Account::User.or_nil({}) # nil
+Kind::Presence.(my_object) # nil
 
-Kind.of.Account::User.instance?({})                # false
-Kind.of.Account::User.instance?(Account::User.new) # true
+my_object.is_blank = false
 
-Kind.of.Account::User.class?(Hash)           # false
-Kind.of.Account::User.class?(Account::User)  # true
+Kind::Presence.(my_object) # #<struct MyObject is_blank=false>
+```
+
+This module also has the method `to_proc`, because of this you can make use of the `Kind::Presence` in methods that receive a block as an argument. e.g:
+
+```ruby
+  ['', [], {}, '1', [2]].map(&Kind::Presence) # [nil, nil, nil, "1", [2]]
+```
+
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
+
+## Kind::Undefined
+
+The [`Kind::Undefined`](https://github.com/serradura/kind/blob/1674bab/lib/kind/undefined.rb) constant can be used to distinguish the usage of `nil`.
+
+If you are interested, check out [the tests](https://github.com/serradura/kind/blob/main/test/kind/undefined_test.rb) to understand its methods.
+
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
+
+## Kind::Maybe
+
+The `Kind::Maybe` is used when a series of computations (in a chain of map callings) could return `nil` or `Kind::Undefined` at any point.
+
+```ruby
+optional =
+  Kind::Maybe.new(2)
+             .map { |value| value * 2 }
+             .map { |value| value * 2 }
+
+puts optional.value # 8
+puts optional.some? # true
+puts optional.none? # false
+puts optional.value_or(0) # 8
+puts optional.value_or { 0 } # 8
+
+#################
+# Returning nil #
+#################
+
+optional =
+  Kind::Maybe.new(3)
+             .map { nil }
+             .map { |value| value * 3 }
+
+puts optional.value # nil
+puts optional.some? # false
+puts optional.none? # true
+puts optional.value_or(0) # 0
+puts optional.value_or { 0 } # 0
+
+#############################
+# Returning Kind::Undefined #
+#############################
+
+optional =
+  Kind::Maybe.new(4)
+             .map { Kind::Undefined }
+             .map { |value| value * 4 }
+
+puts optional.value # Kind::Undefined
+puts optional.some? # false
+puts optional.none? # true
+puts optional.value_or(1) # 1
+puts optional.value_or { 1 } # 1
+```
+
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
+
+#### Replacing blocks by lambdas
+
+```ruby
+Add = -> params do
+  a, b = Kind::Hash.value_or_empty(params).values_at(:a, :b)
+
+  a + b if Kind::Numeric?(a, b)
+end
+
+# --
+
+  Kind::Maybe.new(a: 1, b: 2).map(&Add).value_or(0) # 3
+
+  # --
+
+  Kind::Maybe.new([]).map(&Add).value_or(0) # 0
+  Kind::Maybe.new({}).map(&Add).value_or(0) # 0
+  Kind::Maybe.new(nil).map(&Add).value_or(0) # 0
+```
+
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
+
+### Kind::Maybe[], Kind::Maybe.wrap() and Kind::Maybe#then method aliases
+
+You can use `Kind::Maybe[]` (brackets) instead of the `.new` to transform values in a `Kind::Maybe`. Another alias is `.then` to the `.map` method.
+
+```ruby
+result =
+  Kind::Maybe[5]
+    .then { |value| value * 5 }
+    .then { |value| value + 17 }
+    .value_or(0)
+
+puts result # 42
+```
+
+You can also use `Kind::Maybe.wrap()` instead of the `.new` method.
+
+```ruby
+result =
+  Kind::Maybe
+    .wrap(5)
+    .then { |value| value * 5 }
+    .then { |value| value + 17 }
+    .value_or(0)
+
+puts result # 42
+```
+
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
+
+#### Replacing blocks by lambdas
+
+```ruby
+Add = -> params do
+  a, b = Kind::Hash.value_or_empty(params).values_at(:a, :b)
+
+  a + b if Kind::Numeric?(a, b)
+end
+
+# --
+
+Kind::Maybe[a: 1, b: 2].then(&Add).value_or(0) # 3
+
+# --
+
+Kind::Maybe[1].then(&Add).value_or(0) # 0
+Kind::Maybe['2'].then(&Add).value_or(0) # 0
+Kind::Maybe[nil].then(&Add).value_or(0) # 0
+```
+
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
+
+### Kind::None() and Kind::Some()
+
+If you need to ensure the return of  `Kind::Maybe` results from your methods/lambdas,
+you could use the methods `Kind::None` and `Kind::Some` to do this. e.g:
+
+```ruby
+Double = ->(arg) do
+  number = Kind::Numeric.or_nil(arg)
+
+  Kind::Maybe[number].then { |number| number * 2 }
+end
+
+Add = -> params do
+  a, b = Kind::Hash.value_or_empty(params).values_at(:a, :b)
+
+  return Kind::None unless Kind::Numeric?(a, b)
+
+  Kind::Some(a + b)
+end
+
+# --
+
+Add.call(1)    # #<Kind::Maybe::None:0x0000... @value=nil>
+Add.call({})   # #<Kind::Maybe::None:0x0000... @value=nil>
+Add.call(a: 1) # #<Kind::Maybe::None:0x0000... @value=nil>
+Add.call(b: 2) # #<Kind::Maybe::None:0x0000... @value=nil>
+
+Add.call(a:1, b: 2) # #<Kind::Maybe::Some:0x0000... @value=3>
+
+# --
+
+Kind::Maybe[a: 1, b: 2].then(&Add).value_or(0) # 3
+
+Kind::Maybe[1].then(&Add).value_or(0) # 0
+
+# --
+
+Add.(a: 2, b: 2).then(&Double).value # 8
+```
+
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
+
+### Kind::Optional
+
+The `Kind::Optional` constant is an alias for `Kind::Maybe`. e.g:
+
+```ruby
+result1 =
+  Kind::Optional
+    .new(5)
+    .map { |value| value * 5 }
+    .map { |value| value - 10 }
+    .value_or(0)
+
+puts result1 # 15
 
 # ---
 
-Kind.of.Account::User::Membership({}) # Kind::Error ({} expected to be a kind of Account::User::Membership)
+result2 =
+  Kind::Optional[5]
+    .then { |value| value * 5 }
+    .then { |value| value + 10 }
+    .value_or { 0 }
 
-Kind.of.Account::User::Membership(Account::User::Membership.new)  # #<Account::User::Membership:0x0000...>
-
-Kind.of.Account::User::Membership.or_nil({}) # nil
-
-Kind.of.Account::User::Membership.instance?({})                            # false
-Kind.of.Account::User::Membership.instance?(Account::User::Membership.new) # true
-
-Kind.of.Account::User::Membership.class?(Hash)                      # false
-Kind.of.Account::User::Membership.class?(Account::User::Membership) # true
+puts result2 # 35
 ```
 
-[⬆️ Back to Top](#table-of-contents-)
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
 
-## Type checkers
+#### Replacing blocks by lambdas
 
-The list of types (classes and modules) available to use with `Kind.of.*` or `Kind.is.*` are:
+```ruby
+Double = ->(arg) do
+  number = Kind::Numeric.or_nil(arg)
 
-### Classes' type checkers
+  Kind::Maybe[number].then { |number| number * 2 }
+end
 
-- `Kind.of.String`
-- `Kind.of.Symbol`
-- `Kind.of.Numeric`
-- `Kind.of.Integer`
-- `Kind.of.Float`
-- `Kind.of.Regexp`
-- `Kind.of.Time`
-- `Kind.of.Array`
-- `Kind.of.Range`
-- `Kind.of.Hash`
-- `Kind.of.Struct`
-- `Kind.of.OpenStruct`
-- `Kind.of.Enumerator`
-- `Kind.of.Set`
-- `Kind.of.Method`
-- `Kind.of.Proc`
-- `Kind.of.IO`
-- `Kind.of.File`
+# --
 
-### Modules' type checkers
+Kind::Optional[2].then(&Double).value_or(0) # 4
 
-- `Kind.of.Enumerable`
-- `Kind.of.Comparable`
+# --
 
-### Specials' type checkers
+Kind::Optional['2'].then(&Double).value_or(0) # 0
+Kind::Optional[nil].then(&Double).value_or(0) # 0
+```
 
-- `Kind.of.Class()`
-- `Kind.of.Module()`
-- `Kind.of.Lambda()`
-- `Kind.of.Boolean()`
-- `Kind.of.Callable()`: verifies if the given value `respond_to?(:call)`.
-- `Kind.of.Maybe()` or its alias `Kind.of.Optional()`
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
 
-**Note:** Remember, you can use the `Kind.is.*` method to check if some given value is a class/module with all type checkers above.
+### Kind::Maybe(<Type>)
 
-[⬆️ Back to Top](#table-of-contents-)
+You can use `Kind::Maybe(<Type>)` or `Kind::Optional(<Type>)` to create a maybe monad which will return None if the given input hasn't the expected type. e.g:
+
+```ruby
+result1 =
+  Kind::Maybe(Numeric)
+    .wrap(5)
+    .then { |value| value * 5 }
+    .value_or { 0 }
+
+puts result1 # 25
+
+# ---
+
+result2 =
+  Kind::Optional(Numeric)
+    .wrap('5')
+    .then { |value| value * 5 }
+    .value_or { 0 }
+
+puts result2 # 0
+```
+
+This typed maybe has the same methods of `Kind::Maybe` class. e.g:
+
+```ruby
+Kind::Maybe(Numeric)[5]
+Kind::Maybe(Numeric).new(5)
+Kind::Maybe(Numeric).wrap(5)
+
+# ---
+
+Kind::Optional(Numeric)[5]
+Kind::Optional(Numeric).new(5)
+Kind::Optional(Numeric).wrap(5)
+```
+
+#### Real world examples
+
+It is very common the need to avoid some operation when a method receives the wrong input.
+In these scenarios, you could create a maybe monad that will return None if the given input hasn't the expected type. e.g:
+
+```ruby
+def person_name(params)
+  Kind::Maybe(Hash)
+    .wrap(params)
+    .then  { |hash| hash.values_at(:first_name, :last_name) }
+    .then  { |names| names.map(&Kind::Presence).tap(&:compact!) }
+    .check { |names| names.size == 2 }
+    .then  { |(first_name, last_name)| "#{first_name} #{last_name}" }
+    .value_or { 'John Doe' }
+end
+
+person_name('')   # "John Doe"
+person_name(nil)  # "John Doe"
+
+person_name(first_name: 'Rodrigo')   # "John Doe"
+person_name(last_name: 'Serradura')  # "John Doe"
+
+person_name(first_name: 'Rodrigo', last_name: 'Serradura') # "Rodrigo Serradura"
+
+#
+# See below the previous implementation without using the maybe monad.
+#
+def person_name(params)
+  default = 'John Doe'
+
+  return default unless params.kind_of?(Hash)
+
+  names = params.values_at(:first_name, :last_name).map(&Kind::Presence).tap(&:compact!)
+
+  return default if names.size != 2
+
+  first_name, last_name = default
+
+  "#{first_name} #{last_name}"
+end
+```
+
+To finish follows an example of how to use the Maybe monad to handle arguments in coupled methods.
+
+```ruby
+module PersonIntroduction1
+  extend self
+
+  def call(params)
+    optional = Kind::Maybe(Hash).wrap(params)
+
+    "Hi my name is #{full_name(optional)}, I'm #{age(optional)} years old."
+  end
+
+  private
+
+    def full_name(optional)
+      optional.map { |hash| "#{hash[:first_name]} #{hash[:last_name]}".strip }
+              .presence
+              .value_or { 'John Doe' }
+    end
+
+    def age(optional)
+      optional.map { |hash| hash[:age] }.value_or(0)
+    end
+end
+
+#
+# See below the previous implementation without using an optional.
+#
+module PersonIntroduction2
+  extend self
+
+  def call(params)
+    "Hi my name is #{full_name(params)}, I'm #{age(params)} years old."
+  end
+
+  private
+
+    def full_name(params)
+      default = 'John Doe'
+
+      case params
+      when Hash then
+        Kind::Presence.("#{params[:first_name]} #{params[:last_name]}".strip) || default
+      else default
+      end
+    end
+
+    def age(params)
+      case params
+      when Hash then params.fetch(:age, 0)
+      else 0
+      end
+    end
+end
+```
+
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
+
+### Error handling
+
+#### Kind::Maybe.wrap {}
+
+The `Kind::Maybe#wrap` can receive a block, and if an exception (at `StandardError level`) happening, this will generate a None result.
+
+```ruby
+Kind::Maybe(Numeric)
+  .wrap { 2 / 0 } # #<Kind::Maybe::None:0x0000... @value=#<ZeroDivisionError: divided by 0>>
+
+Kind::Maybe(Numeric)
+  .wrap(2) { |number| number / 0 } # #<Kind::Maybe::None:0x0000... @value=#<ZeroDivisionError: divided by 0>>
+```
+
+#### Kind::Maybe.map! or Kind::Maybe.then!
+
+By default the `Kind::Maybe#map` and `Kind::Maybe#then` intercept exceptions at the `StandardError` level. So if an exception was intercepted a None will be returned.
+
+```ruby
+# Handling StandardError exceptions
+result1 = Kind::Maybe[2].map { |number| number / 0 }
+result1.none? # true
+result1.value # #<ZeroDivisionError: divided by 0>
+
+result2 = Kind::Maybe[3].then { |number| number / 0 }
+result2.none? # true
+result2.value # #<ZeroDivisionError: divided by 0>
+```
+
+But there are versions of these methods (`Kind::Maybe#map!` and `Kind::Maybe#then!`) that allow the exception leak, so, the user must handle the exception by himself or use this method when he wants to see the error be raised.
+
+```ruby
+# Leaking StandardError exceptions
+Kind::Maybe[2].map! { |number| number / 0 } # ZeroDivisionError (divided by 0)
+
+Kind::Maybe[2].then! { |number| number / 0 } # ZeroDivisionError (divided by 0)
+```
+
+> **Note:** If an exception (at StandardError level) is returned by the methods `#then`, `#map` it will be resolved as None.
+
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
+
+### Kind::Maybe#try
+
+If you don't want to use `#map/#then` to access the value, you could use the `#try` method to access it. So, if the value wasn't `nil` or `Kind::Undefined`, the some monad will be returned.
+
+```ruby
+object = 'foo'
+
+Kind::Maybe[object].try(:upcase).value # "FOO"
+
+Kind::Maybe[{}].try(:fetch, :number, 0).value # 0
+
+Kind::Maybe[{number: 1}].try(:fetch, :number).value # 1
+
+Kind::Maybe[object].try { |value| value.upcase }.value # "FOO"
+
+#############
+# Nil value #
+#############
+
+object = nil
+
+Kind::Maybe[object].try(:upcase).value # nil
+
+Kind::Maybe[object].try { |value| value.upcase }.value # nil
+
+#########################
+# Kind::Undefined value #
+#########################
+
+object = Kind::Undefined
+
+Kind::Maybe[object].try(:upcase).value # nil
+
+Kind::Maybe[object].try { |value| value.upcase }.value # nil
+```
+
+> **Note:** You can use the `#try` method with `Kind::Optional` objects.
+
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
+
+### Kind::Maybe#try!
+
+Has the same behavior of its `#try`, but it will raise an error if the value doesn't respond to the expected method.
+
+```ruby
+Kind::Maybe[{}].try(:upcase)  # => #<Kind::Maybe::None:0x0000... @value=nil>
+
+Kind::Maybe[{}].try!(:upcase) # => NoMethodError (undefined method `upcase' for {}:Hash)
+```
+
+> **Note:** You can also use the `#try!` method with `Kind::Optional` objects.
+
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
+
+### Kind::Maybe#dig
+
+Has the same behavior of Ruby dig methods ([Hash](https://ruby-doc.org/core-2.3.0/Hash.html#method-i-dig), [Array](https://ruby-doc.org/core-2.3.0/Array.html#method-i-dig), [Struct](https://ruby-doc.org/core-2.3.0/Struct.html#method-i-dig), [OpenStruct](https://ruby-doc.org/stdlib-2.3.0/libdoc/ostruct/rdoc/OpenStruct.html#method-i-dig)), but it will not raise an error if some value can't be digged.
+
+```ruby
+[nil, 1, '', /x/].each do |value|
+  p Kind::Maybe[value].dig(:foo).value # nil
+end
+
+# --
+
+a = [1, 2, 3]
+
+Kind::Maybe[a].dig(0).value # 1
+
+Kind::Maybe[a].dig(3).value # nil
+
+# --
+
+h = { foo: {bar: {baz: 1}}}
+
+Kind::Maybe[h].dig(:foo).value             # {bar: {baz: 1}}
+Kind::Maybe[h].dig(:foo, :bar).value       # {baz: 1}
+Kind::Maybe[h].dig(:foo, :bar, :baz).value # 1
+
+Kind::Maybe[h].dig(:foo, :bar, 'baz').value # nil
+
+# --
+
+i = { foo: [{'bar' => [1, 2]}, {baz: [3, 4]}] }
+
+Kind::Maybe[i].dig(:foo, 0, 'bar', 0).value # 1
+Kind::Maybe[i].dig(:foo, 0, 'bar', 1).value # 2
+Kind::Maybe[i].dig(:foo, 0, 'bar', -1).value # 2
+
+Kind::Maybe[i].dig(:foo, 0, 'bar', 2).value # nil
+
+# --
+
+s = Struct.new(:a, :b).new(101, 102)
+o = OpenStruct.new(c: 103, d: 104)
+b = { struct: s, ostruct: o, data: [s, o]}
+
+Kind::Maybe[s].dig(:a).value            # 101
+Kind::Maybe[b].dig(:struct, :b).value   # 102
+Kind::Maybe[b].dig(:data, 0, :b).value  # 102
+Kind::Maybe[b].dig(:data, 0, 'b').value # 102
+
+Kind::Maybe[o].dig(:c).value            # 103
+Kind::Maybe[b].dig(:ostruct, :d).value  # 104
+Kind::Maybe[b].dig(:data, 1, :d).value  # 104
+Kind::Maybe[b].dig(:data, 1, 'd').value # 104
+
+Kind::Maybe[s].dig(:f).value           # nil
+Kind::Maybe[o].dig(:f).value           # nil
+Kind::Maybe[b].dig(:struct, :f).value  # nil
+Kind::Maybe[b].dig(:ostruct, :f).value # nil
+Kind::Maybe[b].dig(:data, 0, :f).value # nil
+Kind::Maybe[b].dig(:data, 1, :f).value # nil
+```
+
+> **Note:** You can also use the `#dig` method with `Kind::Optional` objects.
+
+### Kind::Maybe#check
+
+This method will return the current Some after verify if the block output is truthy. e.g:
+
+```ruby
+Kind::Maybe(Array)
+  .wrap(['Rodrigo', 'Serradura'])
+  .then  { |names| names.map(&Kind::Presence).tap(&:compact!) }
+  .check { |names| names.size == 2 }
+  .value # ["Rodrigo", "Serradura"]
+```
+
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
+
+## Kind::Empty
+
+When you define a method that has default arguments, for certain data types, you will always create a new object in memory. e.g:
+
+```ruby
+def something(params = {})
+  params.object_id
+end
+
+puts something # 70312470300460
+puts something # 70312470295800
+puts something # 70312470278400
+puts something # 70312470273800
+```
+
+So, to avoid an unnecessary allocation in memory, the `kind` gem exposes some frozen objects to be used as default values.
+
+- `Kind::Empty::SET`
+- `Kind::Empty::HASH`
+- `Kind::Empty::ARRAY`
+- `Kind::Empty::STRING`
+
+Usage example:
+
+```ruby
+def do_something(value, with_options: Kind::Empty::HASH)
+  # ...
+end
+```
+
+One last thing, if there is no constant declared as Empty, the `kind` gem will define `Empty` as an alias for `Kind::Empty`. Knowing this, the previous example could be written like this:
+
+```ruby
+def do_something(value, with_options: Empty::HASH)
+  # ...
+end
+```
+
+Follows the list of constants, if the alias is available to be created:
+
+- `Empty::SET`
+- `Empty::HASH`
+- `Empty::ARRAY`
+- `Empty::STRING`
+
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
 
 ## Kind::Validator (ActiveModel::Validations)
 
@@ -602,7 +1467,6 @@ validates :name, kind: { instance_of: String }
 validates :name, kind: { instance_of: [String, Symbol] }
 ```
 
-
 **[Object#respond_to?](https://ruby-doc.org/core-2.6.4/Object.html#method-i-respond_to-3F)**
 
 ```ruby
@@ -668,574 +1532,7 @@ validates :first_name, kind: String, strict: true
 validates! :last_name, kind: String
 ```
 
-[⬆️ Back to Top](#table-of-contents-)
-
-## Kind::Undefined
-
-The [`Kind::Undefined`](https://github.com/serradura/kind/blob/834f6b8ebdc737de8e5628986585f30c1a5aa41b/lib/kind/undefined.rb) constant is used as the default argument of type checkers. This is necessary [to know if no arguments were passed to the type check methods](https://github.com/serradura/kind/blob/834f6b8ebdc737de8e5628986585f30c1a5aa41b/lib/kind.rb#L45-L48). But, you can use it in your codebase too, especially if you need to distinguish the usage of `nil` as a method argument.
-
-If you are interested, check out [the tests](https://github.com/serradura/kind/blob/834f6b8ebdc737de8e5628986585f30c1a5aa41b/test/kind/undefined_test.rb) to understand its methods.
-
-### Kind.of.\<Type\>.or_undefined()
-
-If you interested in use `Kind::Undefined` you can use the method `.or_undefined` with any of the [available type checkers](#type-checkers). e.g:
-
-```ruby
-Kind.of.String.or_undefined(nil)         # Kind::Undefined
-Kind.of.String.or_undefined("something") # "something"
-```
-
-[⬆️ Back to Top](#table-of-contents-)
-
-## Kind::Maybe
-
-The `Kind::Maybe` is used when a series of computations (in a chain of map callings) could return `nil` or `Kind::Undefined` at any point.
-
-```ruby
-optional =
-  Kind::Maybe.new(2)
-             .map { |value| value * 2 }
-             .map { |value| value * 2 }
-
-puts optional.value # 8
-puts optional.some? # true
-puts optional.none? # false
-puts optional.value_or(0) # 8
-puts optional.value_or { 0 } # 8
-
-#################
-# Returning nil #
-#################
-
-optional =
-  Kind::Maybe.new(3)
-             .map { nil }
-             .map { |value| value * 3 }
-
-puts optional.value # nil
-puts optional.some? # false
-puts optional.none? # true
-puts optional.value_or(0) # 0
-puts optional.value_or { 0 } # 0
-
-#############################
-# Returning Kind::Undefined #
-#############################
-
-optional =
-  Kind::Maybe.new(4)
-             .map { Kind::Undefined }
-             .map { |value| value * 4 }
-
-puts optional.value # Kind::Undefined
-puts optional.some? # false
-puts optional.none? # true
-puts optional.value_or(1) # 1
-puts optional.value_or { 1 } # 1
-```
-
-#### Replacing blocks by lambdas
-
-```ruby
-Add = -> params do
-  a, b = Kind.of.Hash(params, or: Empty::HASH).values_at(:a, :b)
-
-  a + b if Kind.of.Numeric?(a, b)
-end
-
-# --
-
-  Kind::Maybe.new(a: 1, b: 2).map(&Add).value_or(0) # 3
-
-  # --
-
-  Kind::Maybe.new([]).map(&Add).value_or(0) # 0
-  Kind::Maybe.new({}).map(&Add).value_or(0) # 0
-  Kind::Maybe.new(nil).map(&Add).value_or(0) # 0
-```
-
-### Kind::Maybe[], Kind::Maybe.wrap() and Kind::Maybe#then method aliases
-
-You can use `Kind::Maybe[]` (brackets) instead of the `.new` to transform values in a `Kind::Maybe`. Another alias is `.then` to the `.map` method.
-
-```ruby
-result =
-  Kind::Maybe[5]
-    .then { |value| value * 5 }
-    .then { |value| value + 17 }
-    .value_or(0)
-
-puts result # 42
-```
-
-You can also use `Kind::Maybe.wrap()` instead of the `.new` method.
-
-```ruby
-result =
-  Kind::Maybe
-    .wrap(5)
-    .then { |value| value * 5 }
-    .then { |value| value + 17 }
-    .value_or(0)
-
-puts result # 42
-```
-
-#### Replacing blocks by lambdas
-
-```ruby
-Add = -> params do
-  a, b = Kind.of.Hash(params, or: Empty::HASH).values_at(:a, :b)
-
-  a + b if Kind.of.Numeric.instance?(a, b)
-end
-
-# --
-
-Kind::Maybe[a: 1, b: 2].then(&Add).value_or(0) # 3
-
-# --
-
-Kind::Maybe[1].then(&Add).value_or(0) # 0
-Kind::Maybe['2'].then(&Add).value_or(0) # 0
-Kind::Maybe[nil].then(&Add).value_or(0) # 0
-```
-
-### Kind::None() and Kind::Some()
-
-If you need to ensure the return of  `Kind::Maybe` results from your methods/lambdas,
-you could use the methods `Kind::None` and `Kind::Some` to do this. e.g:
-
-```ruby
-Add = -> params do
-  a, b = Kind.of.Hash(params, or: Empty::HASH).values_at(:a, :b)
-
-  return Kind::None unless Kind.of.Numeric?(a, b)
-
-  Kind::Some(a + b)
-end
-
-# --
-
-Add.call(1)    # #<Kind::Maybe::None:0x0000... @value=nil>
-Add.call({})   # #<Kind::Maybe::None:0x0000... @value=nil>
-Add.call(a: 1) # #<Kind::Maybe::None:0x0000... @value=nil>
-Add.call(b: 2) # #<Kind::Maybe::None:0x0000... @value=nil>
-
-Add.call(a:1, b: 2) # #<Kind::Maybe::Some:0x0000... @value=3>
-
-# --
-
-Kind::Maybe[a: 1, b: 2].then(&Add).value_or(0) # 3
-
-Kind::Maybe[1].then(&Add).value_or(0) # 0
-Kind::Maybe['2'].then(&Add).value_or(0) # 0
-Kind::Maybe[nil].then(&Add).value_or(0) # 0
-```
-
-### Kind.of.Maybe()
-
-You can use the `Kind.of.Maybe()` to know if the given value is a kind of `Kind::Maybe`object. e.g:
-
-```ruby
-def double(maybe_number)
-  Kind.of.Maybe(maybe_number)
-    .map { |value| value * 2 }
-    .value_or(0)
-end
-
-number = Kind::Maybe[4]
-
-puts double(number) # 8
-
-# -------------------------------------------------------#
-# All the type checker methods are available to use too. #
-# -------------------------------------------------------#
-
-Kind.of.Maybe.instance?(number) # true
-
-Kind.of.Maybe.or_nil(number) # <Kind::Maybe::Some @value=4 ...>
-
-Kind.of.Maybe.instance(number) # <Kind::Maybe::Some @value=4 ...>
-Kind.of.Maybe.instance(4) # Kind::Error (4 expected to be a kind of Kind::Maybe::Result)
-
-Kind.of.Maybe[number] # <Kind::Maybe::Some @value=4 ...>
-Kind.of.Maybe[4] # Kind::Error (4 expected to be a kind of Kind::Maybe::Result)
-```
-
-### Kind::Optional
-
-The `Kind::Optional` constant is an alias for `Kind::Maybe`. e.g:
-
-```ruby
-result1 =
-  Kind::Optional
-    .new(5)
-    .map { |value| value * 5 }
-    .map { |value| value - 10 }
-    .value_or(0)
-
-puts result1 # 15
-
-# ---
-
-result2 =
-  Kind::Optional[5]
-    .then { |value| value * 5 }
-    .then { |value| value + 10 }
-    .value_or { 0 }
-
-puts result2 # 35
-```
-
-#### Replacing blocks by lambdas
-
-```ruby
-Add = -> params do
-  a, b = Kind.of.Hash(params, or: Empty::HASH).values_at(:a, :b)
-
-  a + b if Kind.of.Numeric.instance?(a, b)
-end
-
-# --
-
-Kind::Optional[a: 1, b: 2].then(&Add).value_or(0) # 3
-
-# --
-
-Kind::Optional[1].then(&Add).value_or(0) # 0
-Kind::Optional['2'].then(&Add).value_or(0) # 0
-Kind::Optional[nil].then(&Add).value_or(0) # 0
-```
-
-**Note:** The `Kind.of.Optional` is available to check if some value is a `Kind::Optional`.
-
-[⬆️ Back to Top](#table-of-contents-)
-
-### Kind.of.\<Type\>.as_optional
-
-It is very common the need to avoid some computing when a method receives a wrong input.
-In these scenarios, you could check the given input type as optional and avoid unexpected behavior. e.g:
-
-```ruby
-def person_name(params)
-  Kind::Of::Hash
-    .as_optional(params)
-    .map { |data| data if data.values_at(:first_name, :last_name).compact.size == 2 }
-    .map { |data| "#{data[:first_name]} #{data[:last_name]}" }
-    .value_or { 'John Doe' }
-end
-
-person_name('')   # "John Doe"
-person_name(nil)  # "John Doe"
-
-person_name(first_name: 'Rodrigo')   # "John Doe"
-person_name(last_name: 'Serradura')  # "John Doe"
-
-person_name(first_name: 'Rodrigo', last_name: 'Serradura') # "Rodrigo Serradura"
-
-#
-# See below the previous implementation without using an optional.
-#
-def person_name(params)
-  if params.kind_of?(Hash) && params.values_at(:first_name, :last_name).compact.size == 2
-    "#{params[:first_name]} #{params[:last_name]}"
-  else
-    'John Doe'
-  end
-end
-
-#
-# You can also use Kind::Optional(<Type>) to achieve the same behavior
-#
-def person_name(params)
-  Kind::Optional(Hash)
-    .wrap(params)
-    .map { |data| data if data.values_at(:first_name, :last_name).compact.size == 2 }
-    .map { |data| "#{data[:first_name]} #{data[:last_name]}" }
-    .value_or { 'John Doe' }
-end
-```
-
-> Note: You could use the `.as_optional` method (or it alias `.as_maybe`) with any [type checker](https://github.com/serradura/kind/blob/b177fed9cc2b3347d63963a2a2fd99f989c51a9a/README.md#type-checkers).
-
-Let's see another example using a collection and how the method `.as_optional` works when it receives no argument.
-
-```ruby
-collection = [ {number: 1}, 'number 0', {number: 2}, [0] ]
-
-collection
-  .select(&Kind.of.Hash.as_optional)
-  .reduce(0) do |total, item|
-    item.try { |data| data[:number] + total } || total
-  end
-
-collection
-  .map(&Kind.of.Hash.as_optional).select(&:some?)
-  .reduce(0) { |total, item| total + item.value[:number] }
-
-# Note: All the examples above return 3 as the sum of all hashes with numbers.
-```
-
-To finish follows an example of how to use optionals to handle arguments in coupled methods.
-
-```ruby
-module PersonIntroduction
-  extend self
-
-  def call(params)
-    optional = Kind::Of::Hash.as_optional(params)
-
-    "Hi my name is #{full_name(optional)}, I'm #{age(optional)} years old."
-  end
-
-  private
-
-    def full_name(optional)
-      optional.map { |data| "#{data[:first_name]} #{data[:last_name]}" }
-              .value_or { 'John Doe' }
-    end
-
-    def age(optional)
-      optional.map { |data| data[:age] }.value_or(0)
-    end
-end
-
-#
-# See below the previous implementation without using an optional.
-#
-module PersonIntroduction
-  extend self
-
-  def call(params)
-    "Hi my name is #{full_name(params)}, I'm #{age(params)} years old."
-  end
-
-  private
-
-    def full_name(params)
-      case params
-      when Hash then "#{params[:first_name]} #{params[:last_name]}"
-      else 'John Doe'
-      end
-    end
-
-    def age(params)
-      case params
-      when Hash then params.fetch(:age, 0)
-      else 0
-      end
-    end
-end
-```
-
-[⬆️ Back to Top](#table-of-contents-)
-
-### Kind::Maybe(<Type>)
-
-There is an alternative to `Kind.of.\<Type\>.as_optional`, you can use `Kind::Optional(<Type>)` to create a maybe monad which will return None if the given input hasn't the expected type. e.g:
-
-```ruby
-result1 =
-  Kind::Maybe(Numeric)
-    .wrap(5)
-    .then { |value| value * 5 }
-    .value_or { 0 }
-
-puts result1 # 25
-
-# ---
-
-result2 =
-  Kind::Optional(Numeric)
-    .wrap('5')
-    .then { |value| value * 5 }
-    .value_or { 0 }
-
-puts result2 # 0
-```
-
-This typed maybe has the same methods of `Kind::Maybe` class. e.g:
-
-```ruby
-Kind::Maybe(Numeric)[5]
-Kind::Maybe(Numeric).new(5)
-Kind::Maybe(Numeric).wrap(5)
-
-# ---
-
-Kind::Optional(Numeric)[5]
-Kind::Optional(Numeric).new(5)
-Kind::Optional(Numeric).wrap(5)
-```
-
-[⬆️ Back to Top](#table-of-contents-)
-
-### Kind::Maybe#try
-
-If you don't want to use `#map/#then` to access the value, you could use the `#try` method to access it. So, if the value wasn't `nil` or `Kind::Undefined`, the some monad will be returned.
-
-```ruby
-object = 'foo'
-
-Kind::Maybe[object].try(:upcase).value # "FOO"
-
-Kind::Maybe[{}].try(:fetch, :number, 0).value # 0
-
-Kind::Maybe[{number: 1}].try(:fetch, :number).value # 1
-
-Kind::Maybe[object].try { |value| value.upcase }.value # "FOO"
-
-#############
-# Nil value #
-#############
-
-object = nil
-
-Kind::Maybe[object].try(:upcase).value # nil
-
-Kind::Maybe[object].try { |value| value.upcase }.value # nil
-
-#########################
-# Kind::Undefined value #
-#########################
-
-object = Kind::Undefined
-
-Kind::Maybe[object].try(:upcase).value # nil
-
-Kind::Maybe[object].try { |value| value.upcase }.value # nil
-```
-
-> **Note:** You can use the `#try` method with `Kind::Optional` objects.
-
-[⬆️ Back to Top](#table-of-contents-)
-
-### Kind::Maybe#try!
-
-Has the same behavior of its `#try`, but it will raise an error if the value doesn't respond to the expected method.
-
-```ruby
-Kind::Maybe[{}].try(:upcase)  # => #<Kind::Maybe::None:0x0000... @value=nil>
-
-Kind::Maybe[{}].try!(:upcase) # => NoMethodError (undefined method `upcase' for {}:Hash)
-```
-
-> **Note:** You can also use the `#try!` method with `Kind::Optional` objects.
-
-[⬆️ Back to Top](#table-of-contents-)
-
-### Kind::Maybe#dig
-
-Has the same behavior of Ruby dig methods ([Hash](https://ruby-doc.org/core-2.3.0/Hash.html#method-i-dig), [Array](https://ruby-doc.org/core-2.3.0/Array.html#method-i-dig), [Struct](https://ruby-doc.org/core-2.3.0/Struct.html#method-i-dig), [OpenStruct](https://ruby-doc.org/stdlib-2.3.0/libdoc/ostruct/rdoc/OpenStruct.html#method-i-dig)), but it will not raise an error if some value can't be digged.
-
-```ruby
-[nil, 1, '', /x/].each do |value|
-  p Kind::Maybe[value].dig(:foo).value # nil
-end
-
-# --
-
-a = [1, 2, 3]
-
-Kind::Maybe[a].dig(0).value # 1
-
-Kind::Maybe[a].dig(3).value # nil
-
-# --
-
-h = { foo: {bar: {baz: 1}}}
-
-Kind::Maybe[h].dig(:foo).value             # {bar: {baz: 1}}
-Kind::Maybe[h].dig(:foo, :bar).value       # {baz: 1}
-Kind::Maybe[h].dig(:foo, :bar, :baz).value # 1
-
-Kind::Maybe[h].dig(:foo, :bar, 'baz').value # nil
-
-# --
-
-i = { foo: [{'bar' => [1, 2]}, {baz: [3, 4]}] }
-
-Kind::Maybe[i].dig(:foo, 0, 'bar', 0).value # 1
-Kind::Maybe[i].dig(:foo, 0, 'bar', 1).value # 2
-Kind::Maybe[i].dig(:foo, 0, 'bar', -1).value # 2
-
-Kind::Maybe[i].dig(:foo, 0, 'bar', 2).value # nil
-
-# --
-
-s = Struct.new(:a, :b).new(101, 102)
-o = OpenStruct.new(c: 103, d: 104)
-b = { struct: s, ostruct: o, data: [s, o]}
-
-Kind::Maybe[s].dig(:a).value            # 101
-Kind::Maybe[b].dig(:struct, :b).value   # 102
-Kind::Maybe[b].dig(:data, 0, :b).value  # 102
-Kind::Maybe[b].dig(:data, 0, 'b').value # 102
-
-Kind::Maybe[o].dig(:c).value            # 103
-Kind::Maybe[b].dig(:ostruct, :d).value  # 104
-Kind::Maybe[b].dig(:data, 1, :d).value  # 104
-Kind::Maybe[b].dig(:data, 1, 'd').value # 104
-
-Kind::Maybe[s].dig(:f).value           # nil
-Kind::Maybe[o].dig(:f).value           # nil
-Kind::Maybe[b].dig(:struct, :f).value  # nil
-Kind::Maybe[b].dig(:ostruct, :f).value # nil
-Kind::Maybe[b].dig(:data, 0, :f).value # nil
-Kind::Maybe[b].dig(:data, 1, :f).value # nil
-```
-
-> **Note:** You can also use the `#dig` method with `Kind::Optional` objects.
-
-[⬆️ Back to Top](#table-of-contents-)
-
-## Kind::Empty
-
-When you define a method that has default arguments, for certain data types, you will always create a new object in memory. e.g:
-
-```ruby
-def something(params = {})
-  params.object_id
-end
-
-puts something # 70312470300460
-puts something # 70312470295800
-puts something # 70312470278400
-puts something # 70312470273800
-```
-
-So, to avoid an unnecessary allocation in memory, the `kind` gem exposes some frozen objects to be used as default values.
-
-- `Kind::Empty::SET`
-- `Kind::Empty::HASH`
-- `Kind::Empty::ARRAY`
-- `Kind::Empty::STRING`
-
-Usage example:
-
-```ruby
-def do_something(value, with_options: Kind::Empty::HASH)
-  # ...
-end
-```
-
-One last thing, if there is no constant declared as Empty, the `kind` gem will define `Empty` as an alias for `Kind::Empty`. Knowing this, the previous example could be written like this:
-
-```ruby
-def do_something(value, with_options: Empty::HASH)
-  # ...
-end
-```
-
-Follows the list of constants, if the alias is available to be created:
-
-- `Empty::SET`
-- `Empty::HASH`
-- `Empty::ARRAY`
-- `Empty::STRING`
-
-[⬆️ Back to Top](#table-of-contents-)
+[⬆️ &nbsp;Back to Top](#table-of-contents-)
 
 ## Similar Projects
 

--- a/lib/kind.rb
+++ b/lib/kind.rb
@@ -76,6 +76,10 @@ module Kind
     end
   end
 
+  def self.value(kind, value, default:)
+    KIND.value(kind, value, of(kind, default))
+  end
+
   def self.Of(kind, opt = Empty::HASH)
     TypeChecker::Object.new(kind, opt)
   end

--- a/lib/kind/core/kind.rb
+++ b/lib/kind/core/kind.rb
@@ -53,5 +53,9 @@ module Kind
         kind == expected_kind || kind.kind_of?(expected_kind)
       end
     end
+
+    def self.value(kind, arg, default) # :nodoc:
+      kind === arg ? arg : default
+    end
   end
 end

--- a/lib/kind/dig.rb
+++ b/lib/kind/dig.rb
@@ -16,6 +16,10 @@ module Kind
       end
     end
 
+    def [](*keys)
+      ->(data) { call(data, keys) }
+    end
+
     private
 
       def get(data, key)

--- a/lib/kind/maybe/none.rb
+++ b/lib/kind/maybe/none.rb
@@ -20,6 +20,7 @@ module Kind
       alias_method :map!, :map
       alias_method :then, :map
       alias_method :then!, :map
+      alias_method :check, :map
 
       def try!(method_name = UNDEFINED, *args, &block)
         Kind::Symbol[method_name] if UNDEFINED != method_name

--- a/lib/kind/maybe/result.rb
+++ b/lib/kind/maybe/result.rb
@@ -23,6 +23,14 @@ module Kind
         raise NotImplementedError
       end
 
+      alias_method :map!, :map
+      alias_method :then, :map
+      alias_method :then!, :map
+
+      def check(&fn)
+        raise NotImplementedError
+      end
+
       def try(method_name = UNDEFINED, &block)
         raise NotImplementedError
       end

--- a/lib/kind/maybe/result.rb
+++ b/lib/kind/maybe/result.rb
@@ -5,8 +5,10 @@ module Kind
     class Result
       attr_reader :value
 
-      def initialize(value)
-        @value = value.kind_of?(Result) ? value.value : value
+      Value = ->(arg) { arg.kind_of?(::Kind::Maybe::Result) ? arg.value : arg } # :nodoc:
+
+      def initialize(arg)
+        @value = Value.(arg)
       end
 
       def value_or(method_name = UNDEFINED, &block)

--- a/lib/kind/maybe/some.rb
+++ b/lib/kind/maybe/some.rb
@@ -17,6 +17,12 @@ module Kind
 
       alias_method :then, :map
 
+      def check(&fn)
+        result = fn.call(@value)
+
+        !result || KIND.null?(result) ? NONE_WITH_NIL_VALUE : self
+      end
+
       def map!(&fn)
         result = fn.call(@value)
 

--- a/lib/kind/maybe/typed.rb
+++ b/lib/kind/maybe/typed.rb
@@ -9,7 +9,9 @@ module Kind
         @kind = kind
       end
 
-      def new(value)
+      def new(arg)
+        value = Result::Value.(arg)
+
         value.kind_of?(@kind) ? Maybe.some(value) : Maybe.none
       end
 

--- a/lib/kind/maybe/typed.rb
+++ b/lib/kind/maybe/typed.rb
@@ -16,6 +16,14 @@ module Kind
       end
 
       alias_method :[], :new
+
+      private
+
+        def __call_before_expose_the_arg_in_a_block(arg)
+          value = Result::Value.(arg)
+
+          value.kind_of?(@kind) ? value : Maybe.none
+        end
     end
   end
 end

--- a/lib/kind/maybe/wrappable.rb
+++ b/lib/kind/maybe/wrappable.rb
@@ -8,7 +8,11 @@ module Kind
       def wrap(arg = UNDEFINED)
         if block_given?
           begin
-            new(UNDEFINED == arg ? yield : yield(arg))
+            return new(yield) if UNDEFINED == arg
+
+            input = __call_before_expose_the_arg_in_a_block(arg)
+
+            input.kind_of?(Kind::Maybe::None) ? input : new(yield(input))
           rescue StandardError => exception
             Maybe.__none__(exception)
           end
@@ -18,6 +22,12 @@ module Kind
           raise ArgumentError, WRONG_NUMBER_OF_ARGS
         end
       end
+
+      private
+
+        def __call_before_expose_the_arg_in_a_block(input)
+          input
+        end
     end
 
     private_constant :Wrappable

--- a/lib/kind/presence.rb
+++ b/lib/kind/presence.rb
@@ -16,6 +16,10 @@ module Kind
       return object if object
     end
 
+    def to_proc
+      -> object { call(object) }
+    end
+
     private
 
       BLANK_RE = /\A[[:space:]]*\z/

--- a/lib/kind/try.rb
+++ b/lib/kind/try.rb
@@ -7,9 +7,21 @@ module Kind
     def call(*args)
       object = args.shift
 
+      call!(object, args.shift, args)
+    end
+
+    def self.[](*args)
+      Array[args]
+
+      method_name = args.shift
+
+      ->(object) { call!(object, method_name, args) }
+    end
+
+    def call!(object, method_name, args) # :nodoc
       return if KIND.null?(object)
 
-      resolve(object, args.shift, args)
+      resolve(object, method_name, args)
     end
 
     private

--- a/lib/kind/type_checker.rb
+++ b/lib/kind/type_checker.rb
@@ -37,7 +37,7 @@ module Kind
     end
 
     def value(arg, default:)
-      __value(arg, self[default])
+      KIND.value(self, arg, self[default])
     end
 
     def or_null(value) # :nodoc:
@@ -48,10 +48,6 @@ module Kind
 
       def __or_func
         @__or_func ||= ->(tc, fb, value) { tc === value ? value : tc.or_null(fb) }.curry[self]
-      end
-
-      def __value(arg, default)
-        self === arg ? arg : default
       end
   end
 

--- a/lib/kind/type_checkers/core/array.rb
+++ b/lib/kind/type_checkers/core/array.rb
@@ -7,7 +7,7 @@ module Kind
     def kind; ::Array; end
 
     def value_or_empty(arg)
-      __value(arg, Empty::ARRAY)
+      KIND.value(self, arg, Empty::ARRAY)
     end
   end
 

--- a/lib/kind/type_checkers/core/hash.rb
+++ b/lib/kind/type_checkers/core/hash.rb
@@ -7,7 +7,7 @@ module Kind
     def kind; ::Hash; end
 
     def value_or_empty(arg)
-      __value(arg, Empty::HASH)
+      KIND.value(self, arg, Empty::HASH)
     end
   end
 

--- a/lib/kind/type_checkers/core/string.rb
+++ b/lib/kind/type_checkers/core/string.rb
@@ -7,7 +7,7 @@ module Kind
     def kind; ::String; end
 
     def value_or_empty(arg)
-      __value(arg, Empty::STRING)
+      KIND.value(self, arg, Empty::STRING)
     end
   end
 

--- a/lib/kind/type_checkers/stdlib/set.rb
+++ b/lib/kind/type_checkers/stdlib/set.rb
@@ -7,7 +7,7 @@ module Kind
     def kind; ::Set; end
 
     def value_or_empty(arg)
-      __value(arg, Empty::SET)
+      KIND.value(self, arg, Empty::SET)
     end
   end
 

--- a/lib/kind/version.rb
+++ b/lib/kind/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Kind
-  VERSION = '3.1.0'
+  VERSION = '4.0.0'
 end

--- a/test/kind/dig_test.rb
+++ b/test/kind/dig_test.rb
@@ -48,4 +48,17 @@ class Kind::DigTest < Minitest::Test
 
     assert 'Rodrigo' == Kind::Dig.({people: [person]}, [:people, 0, :name])
   end
+
+  def test_the_creation_of_a_lambda_that_knows_how_to_performs_the_try_strategy
+    results = [
+      { person: {} },
+      { person: { name: 'Foo Bar'} },
+      { person: { name: 'Rodrigo Serradura'} },
+    ].map(&Kind::Dig[:person, :name])
+
+    assert_equal(
+      [nil, 'Foo Bar', 'Rodrigo Serradura'],
+      results
+    )
+  end
 end

--- a/test/kind/maybe_test.rb
+++ b/test/kind/maybe_test.rb
@@ -629,6 +629,25 @@ class Kind::MaybeTest < Minitest::Test
     end
   end
 
+  def test_the_check_method
+    person_name = ->(params) do
+      Kind::Maybe(Hash)
+        .wrap(params)
+        .then  { |hash| hash.values_at(:first_name, :last_name) }
+        .then  { |names| names.map(&Kind::Presence).tap(&:compact!) }
+        .check { |names| names.size == 2 }
+        .then  { |(first_name, last_name)| "#{first_name} #{last_name}" }
+        .value_or { 'John Doe' }
+    end
+
+    assert 'John Doe' == person_name.('')
+    assert 'John Doe' == person_name.(nil)
+    assert 'John Doe' == person_name.(last_name: 'Serradura')
+    assert 'John Doe' == person_name.(first_name: 'Rodrigo')
+
+    assert 'Rodrigo Serradura' == person_name.(first_name: 'Rodrigo', last_name: 'Serradura')
+  end
+
   def test_that_the_wrap_method_of_a_typed_maybe_verifies_if_the_block_arg_has_the_right_kind
     assert_nil(Kind::Maybe(Numeric).wrap('2') { |number| number / 0 }.value)
 

--- a/test/kind/maybe_test.rb
+++ b/test/kind/maybe_test.rb
@@ -17,6 +17,10 @@ class Kind::MaybeTest < Minitest::Test
     assert_raises(NotImplementedError) { maybe_result.none? }
     assert_raises(NotImplementedError) { maybe_result.some? }
     assert_raises(NotImplementedError) { maybe_result.map { 0 } }
+    assert_raises(NotImplementedError) { maybe_result.map! { 0 } }
+    assert_raises(NotImplementedError) { maybe_result.then { 0 } }
+    assert_raises(NotImplementedError) { maybe_result.then! { 0 } }
+    assert_raises(NotImplementedError) { maybe_result.check { true } }
     assert_raises(NotImplementedError) { maybe_result.try(:anything) }
     assert_raises(NotImplementedError) { maybe_result.try!(:anything) }
     assert_raises(NotImplementedError) { maybe_result.try { |value| value.anything } }

--- a/test/kind/maybe_test.rb
+++ b/test/kind/maybe_test.rb
@@ -486,7 +486,9 @@ class Kind::MaybeTest < Minitest::Test
     assert_predicate(Kind::Maybe(Hash).new([]), :none?)
 
     assert_predicate(Kind::Maybe(Hash)[{}], :some?)
+    assert_predicate(Kind::Maybe(Hash)[Kind::Some({})], :some?)
     assert_predicate(Kind::Maybe(Hash).new({}), :some?)
+    assert_predicate(Kind::Maybe(Hash).new(Kind::Some({})), :some?)
 
     # ---
 
@@ -494,7 +496,9 @@ class Kind::MaybeTest < Minitest::Test
     assert_predicate(Kind::Optional(Hash).new([]), :none?)
 
     assert_predicate(Kind::Optional(Hash)[{}], :some?)
+    assert_predicate(Kind::Optional(Hash)[Kind::Some({})], :some?)
     assert_predicate(Kind::Optional(Hash).new({}), :some?)
+    assert_predicate(Kind::Optional(Hash).new(Kind::Some({})), :some?)
   end
 
   def test_the_wrap_method
@@ -526,6 +530,9 @@ class Kind::MaybeTest < Minitest::Test
 
     assert_predicate(Kind::Optional(Hash).wrap(''), :none?)
     assert_predicate(Kind::Optional(Hash).wrap({}), :some?)
+    assert_predicate(Kind::Optional(Hash).wrap(Kind::Some({})), :some?)
+
+    assert_predicate(Kind::Optional(Hash).wrap { Kind::Some({}) }, :some?)
 
     exception2 = Kind::Maybe(Numeric).wrap { 3 / 0 }
     assert_predicate(exception2, :none?)

--- a/test/kind/maybe_test.rb
+++ b/test/kind/maybe_test.rb
@@ -628,4 +628,13 @@ class Kind::MaybeTest < Minitest::Test
       Kind::Maybe.new(0).then! { |value| 2 / value }
     end
   end
+
+  def test_that_the_wrap_method_of_a_typed_maybe_verifies_if_the_block_arg_has_the_right_kind
+    assert_nil(Kind::Maybe(Numeric).wrap('2') { |number| number / 0 }.value)
+
+    assert_instance_of(
+      ZeroDivisionError,
+      Kind::Maybe(Numeric).wrap(2) { |number| number / 0 }.value
+    )
+  end
 end

--- a/test/kind/presence_test.rb
+++ b/test/kind/presence_test.rb
@@ -10,6 +10,7 @@ class Kind::PresenceTest < Minitest::Test
       @state
     end
   end
+
   def test_the_presence_of_several_objects
     # object#blank?
     assert_nil Kind::Presence.(IsBlank.new(true))
@@ -44,5 +45,12 @@ class Kind::PresenceTest < Minitest::Test
     assert_nil Kind::Presence.(false)
 
     assert OpenStruct === Kind::Presence.(OpenStruct.new)
+  end
+
+  def test_to_proc
+    assert_equal(
+      [nil, nil, nil, "1", [2]],
+      ['', [], {}, '1', [2]].map(&Kind::Presence)
+    )
   end
 end

--- a/test/kind/try_test.rb
+++ b/test/kind/try_test.rb
@@ -20,4 +20,18 @@ class Kind::TryTest < Minitest::Test
       '1 is not a symbol nor a string',
     ) { Kind::Try.({a: 1}, 1, :a) }
   end
+
+  def test_the_creation_of_a_lambda_that_knows_how_to_performs_the_try_strategy
+    results =
+      [
+        {},
+        {name: 'Foo Bar'},
+        {name: 'Rodrigo Serradura'},
+      ].map(&Kind::Try[:fetch, :name, 'John Doe'])
+
+    assert_equal(
+      ['John Doe', 'Foo Bar', 'Rodrigo Serradura'],
+      results
+    )
+  end
 end

--- a/test/kind/utility_methods_test.rb
+++ b/test/kind/utility_methods_test.rb
@@ -116,4 +116,16 @@ class Kind::UtilityMethodsTest < Minitest::Test
 
     refute_same(kind_symbol1, kind_symbol2)
   end
+
+  def test_Kind_value
+    assert '1' == Kind.value(String, '1', default: '')
+
+    assert '' == Kind.value(String, 1, default: '')
+
+    # FACT: The default value must be of the expected kind.
+    assert_raises_with_message(
+      Kind::Error,
+      '2 expected to be a kind of String'
+    ) { Kind.value(String, 1, default: 2) }
+  end
 end


### PR DESCRIPTION
- Update README.md and CHANGELOG.md

- Bump version to 4.0.0

- Add the method `Kind.value`. This method ensures that you will have a value of the expected kind. But, in the case of the given value be invalid, this method will require a default value (with the expected kind) to be returned.
  ```ruby
  Kind.value(String, '1', default: '') # "1"

  Kind.value(String, 1, default: '')   # ""

  Kind.value(String, 1, default: 2)    # Kind::Error (2 expected to be a kind of String)
  ```

- Add `Kind::Presence.to_proc`. This method allow you to make use of the `Kind::Presence` in methods that receive a block as an argument. e.g:
  ```ruby
  ['', [], {}, '1', [2]].map(&Kind::Presence) # [nil, nil, nil, "1", [2]]
  ```

- `Kind::Maybe(<Type>).{new,[],wrap}` Now, these methods know how to get the value of another Maybe monad.
  ```ruby
  some_number = Kind::Some(2)

  Kind::Maybe(Numeric)[some_number] # #<Kind::Maybe::Some:0x0000... @value=2>

  Kind::Maybe(Numeric).new(some_number) # #<Kind::Maybe::Some:0x0000... @value=2>

  Kind::Maybe(Numeric).wrap(some_number) # #<Kind::Maybe::Some:0x0000... @value=2>

  Kind::Maybe(Numeric).wrap { some_number } # #<Kind::Maybe::Some:0x0000... @value=2>

  Kind::Maybe(Numeric).wrap(some_number) { |number| number / 2 } # #<Kind::Maybe::Some:0x0000... @value=1>
  ```

- `Kind::Maybe(<Type>).wrap(arg) { |arg_value| }` if the block receives an argument, the typed Maybe monad will verify if the argument is from the expected kind.
  ```ruby
    Kind::Maybe(Numeric).wrap('2') { |number| number / 0 } # #<Kind::Maybe::None:0x0000... @value=nil>

    Kind::Maybe(Numeric).wrap(2) { |number| number / 0 } # #<Kind::Maybe::None:0x0000... @value=#<ZeroDivisionError: divided by 0>>
  ```

- Add `Kind::Maybe#check`. This method returns the current Some after verifies if the block output was truthy.
  ```ruby
  person_name = ->(params) do
    Kind::Maybe(Hash)
      .wrap(params)
      .then  { |hash| hash.values_at(:first_name, :last_name) }
      .then  { |names| names.map(&Kind::Presence).tap(&:compact!) }
      .check { |names| names.size == 2 }
      .then  { |(first_name, last_name)| "#{first_name} #{last_name}" }
      .value_or { 'John Doe' }
  end

  person_name.('')                     # "John Doe"
  person_name.(nil)                    # "John Doe"
  person_name.(last_name: 'Serradura') # "John Doe"
  person_name.(first_name: 'Rodrigo')  # "John Doe"

  person_name.(first_name: 'Rodrigo', last_name: 'Serradura') # "Rodrigo Serradura"
  ```

- Add `Kind::Dig[]`. This method knows how to create a lambda that will know how to perform the dig strategy.
  ```ruby
  results = [
    { person: {} },
    { person: { name: 'Foo Bar'} },
    { person: { name: 'Rodrigo Serradura'} },
  ].map(&Kind::Dig[:person, :name])

  p results # [nil, "Foo Bar", "Rodrigo Serradura"],
  ```

- Add `Kind::Try[]`. This method knows how to create a lambda that will know how to perform the try strategy.
  ```ruby
  results =
    [
      {},
      {name: 'Foo Bar'},
      {name: 'Rodrigo Serradura'},
    ].map(&Kind::Try[:fetch, :name, 'John Doe'])

  p results # ["John Doe", "Foo Bar", "Rodrigo Serradura"]
  ```