### PR TITLE
Add optimizations and feature improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,61 +3,63 @@
 This project follows [semver 2.0.0](http://semver.org/spec/v2.0.0.html) and the recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 - [Unreleased](#unreleased)
-- [4.0.0 (2021-02-22)](#400-2021-02-22)
+- [4.1.0 (2021-02-22)](#410-2021-02-22)
   - [Added](#added)
+- [4.0.0 (2021-02-22)](#400-2021-02-22)
+  - [Added](#added-1)
   - [Deprecated](#deprecated)
   - [Fixed](#fixed)
 - [3.1.0 (2020-07-08)](#310-2020-07-08)
-  - [Added](#added-1)
+  - [Added](#added-2)
 - [3.0.0 (2020-06-25)](#300-2020-06-25)
   - [Breaking Changes](#breaking-changes)
-  - [Added](#added-2)
-- [2.3.0 (2020-06-24)](#230-2020-06-24)
   - [Added](#added-3)
-- [2.2.0 (2020-06-23)](#220-2020-06-23)
+- [2.3.0 (2020-06-24)](#230-2020-06-24)
   - [Added](#added-4)
-- [2.1.0 (2020-05-12)](#210-2020-05-12)
+- [2.2.0 (2020-06-23)](#220-2020-06-23)
   - [Added](#added-5)
+- [2.1.0 (2020-05-12)](#210-2020-05-12)
+  - [Added](#added-6)
   - [Breaking Changes](#breaking-changes-1)
 - [2.0.0 (2020-05-07)](#200-2020-05-07)
-  - [Added](#added-6)
+  - [Added](#added-7)
   - [Breaking Changes](#breaking-changes-2)
   - [Removed](#removed)
 - [1.9.0 (2020-05-06)](#190-2020-05-06)
-  - [Added](#added-7)
-- [1.8.0 (2020-05-03)](#180-2020-05-03)
   - [Added](#added-8)
+- [1.8.0 (2020-05-03)](#180-2020-05-03)
+  - [Added](#added-9)
 - [1.7.0 (2020-05-03)](#170-2020-05-03)
   - [Fixed](#fixed-1)
 - [1.6.0 (2020-04-17)](#160-2020-04-17)
-  - [Added](#added-9)
+  - [Added](#added-10)
   - [Changes](#changes)
 - [1.5.0 (2020-04-12)](#150-2020-04-12)
-  - [Added](#added-10)
-- [1.4.0 (2020-04-12)](#140-2020-04-12)
   - [Added](#added-11)
-- [1.3.0 (2020-04-12)](#130-2020-04-12)
+- [1.4.0 (2020-04-12)](#140-2020-04-12)
   - [Added](#added-12)
-- [1.2.0 (2020-04-12)](#120-2020-04-12)
+- [1.3.0 (2020-04-12)](#130-2020-04-12)
   - [Added](#added-13)
-- [1.1.0 (2020-04-09)](#110-2020-04-09)
+- [1.2.0 (2020-04-12)](#120-2020-04-12)
   - [Added](#added-14)
+- [1.1.0 (2020-04-09)](#110-2020-04-09)
+  - [Added](#added-15)
   - [Fixed](#fixed-2)
 - [1.0.0 (2020-03-16)](#100-2020-03-16)
-  - [Added](#added-15)
-- [0.6.0 (2020-01-06)](#060-2020-01-06)
   - [Added](#added-16)
-- [0.5.0 (2020-01-04)](#050-2020-01-04)
+- [0.6.0 (2020-01-06)](#060-2020-01-06)
   - [Added](#added-17)
-- [0.4.0 (2020-01-03)](#040-2020-01-03)
+- [0.5.0 (2020-01-04)](#050-2020-01-04)
   - [Added](#added-18)
-- [0.3.0 (2020-01-03)](#030-2020-01-03)
+- [0.4.0 (2020-01-03)](#040-2020-01-03)
   - [Added](#added-19)
+- [0.3.0 (2020-01-03)](#030-2020-01-03)
+  - [Added](#added-20)
   - [Breaking Changes](#breaking-changes-3)
 - [0.2.0 (2020-01-02)](#020-2020-01-02)
-  - [Added](#added-20)
-- [0.1.0 (2019-12-26)](#010-2019-12-26)
   - [Added](#added-21)
+- [0.1.0 (2019-12-26)](#010-2019-12-26)
+  - [Added](#added-22)
 
 ## Unreleased
 
@@ -68,6 +70,41 @@ This project follows [semver 2.0.0](http://semver.org/spec/v2.0.0.html) and the 
 ### Removed
 ### Fixed
 -->
+
+4.1.0 (2021-02-22)
+------------------
+
+### Added
+
+* [#43](https://github.com/serradura/kind/pull/43) - Make `Kind::Maybe::Typed` verify the kind of the value via `===`, because of this, now is possible to use type checkers in typed Maybes.
+  ```ruby
+  Kind::Maybe(Kind::Boolean).wrap(nil).value_or(false)  # false
+
+  Kind::Maybe(Kind::Boolean).wrap(true).value_or(false) # true
+  ```
+
+* [#43](https://github.com/serradura/kind/pull/43) - Add `Kind::<Type>.maybe` and `Kind::<Type>.optional`. This method returns a typed Maybe with the expected kind when it is invoked without arguments. But, if it receives arguments, it will behave like the `Kind::Maybe.wrap` method. e.g.
+  ```ruby
+  Kind::Integer.maybe #<Kind::Maybe::Typed:0x0000... @kind=Kind::Integer>
+
+  Kind::Integer.maybe(0).some?               # true
+  Kind::Integer.maybe { 1 }.some?            # true
+  Kind::Integer.maybe(2) { |n| n * 2 }.some? # true
+
+  Kind::Integer.maybe { 2 / 0 }.none?          # true
+  Kind::Integer.maybe(2) { |n| n / 0 }.none?   # true
+  Kind::Integer.maybe('2') { |n| n * n }.none? # true
+  ```
+
+* [#43](https://github.com/serradura/kind/pull/43) - Make the `:respond_to` kind validation verify by one or multiple methods. e.g.
+  ```ruby
+  validates :params, kind: { respond_to: [:[], :values_at] }
+  ```
+
+* [#43](https://github.com/serradura/kind/pull/43) - Make the `:of` kind validation verify the expected value kind using `===`, because of this, now is possible to use type checkers as expected kinds. e.g.
+  ```ruby
+  validates :alive, kind: Kind::Boolean
+  ```
 
 4.0.0 (2021-02-22)
 ------------------

--- a/lib/kind.rb
+++ b/lib/kind.rb
@@ -12,10 +12,10 @@ require 'kind/dig'
 require 'kind/try'
 require 'kind/presence'
 require 'kind/undefined'
-require 'kind/type_checker'
-
-require 'kind/type_checkers'
 require 'kind/maybe'
+
+require 'kind/type_checker'
+require 'kind/type_checkers'
 
 require 'kind/deprecations/checker'
 require 'kind/deprecations/of'

--- a/lib/kind.rb
+++ b/lib/kind.rb
@@ -59,7 +59,7 @@ module Kind
 
     return is?(expected, object) if UNDEFINED != object
 
-    raise ArgumentError, 'wrong number of arguments (given 1, expected 2)'
+    WRONG_NUMBER_OF_ARGS.error!(given: 1, expected: 2)
   end
 
   def self.of(kind = UNDEFINED, object = UNDEFINED)

--- a/lib/kind/active_model/kind_validator.rb
+++ b/lib/kind/active_model/kind_validator.rb
@@ -35,9 +35,9 @@ class KindValidator < ActiveModel::EachValidator
     def kind_of(expected, value)
       types = Array(expected)
 
-      return if types.any? { |type| value.kind_of?(type) }
+      return if types.any? { |type| type === value }
 
-      "must be a kind of: #{types.map { |klass| klass.name }.join(', ')}"
+      "must be a kind of: #{types.map { |type| type.name }.join(', ')}"
     end
 
     CLASS_OR_MODULE = 'Class/Module'.freeze

--- a/lib/kind/active_model/kind_validator.rb
+++ b/lib/kind/active_model/kind_validator.rb
@@ -45,7 +45,7 @@ class KindValidator < ActiveModel::EachValidator
     def kind_is(expected, value)
       return kind_is_not(expected, value) unless expected.kind_of?(::Array)
 
-      result = expected.map { |kind| kind_is_not(kind, value) }.compact
+      result = expected.map { |kind| kind_is_not(kind, value) }.tap(&:compact!)
 
       result.empty? || result.size < expected.size ? nil : result.join(', ')
     end

--- a/lib/kind/active_model/kind_validator.rb
+++ b/lib/kind/active_model/kind_validator.rb
@@ -66,10 +66,17 @@ class KindValidator < ActiveModel::EachValidator
       end
     end
 
-    def respond_to(method_name, value)
-      return if value.respond_to?(method_name)
+    def respond_to(expected, value)
+      method_names = Array(expected)
 
-      "must respond to the method `#{method_name}`"
+      expected_methods = method_names.select { |method_name| !value.respond_to?(method_name) }
+      expected_methods.map! { |method_name| "`#{method_name}`" }
+
+      return if expected_methods.empty?
+
+      methods = expected_methods.size == 1 ? 'method' : 'methods'
+
+      "must respond to the #{methods}: #{expected_methods.join(', ')}"
     end
 
     def instance_of(expected, value)

--- a/lib/kind/core.rb
+++ b/lib/kind/core.rb
@@ -2,6 +2,7 @@
 
 module Kind
   module Core
+    require 'kind/core/wrong_number_of_args'
     require 'kind/core/deprecation'
     require 'kind/core/kind'
     require 'kind/core/undefined'

--- a/lib/kind/core/kind.rb
+++ b/lib/kind/core/kind.rb
@@ -27,7 +27,7 @@ module Kind
     end
 
     def self.of_module?(value) # :nodoc:
-      ::Module == value || (value.is_a?(::Module) && !of_class?(value))
+      ::Module == value || (value.kind_of?(::Module) && !of_class?(value))
     end
 
     def self.of_module_or_class!(value) # :nodoc:

--- a/lib/kind/core/wrong_number_of_args.rb
+++ b/lib/kind/core/wrong_number_of_args.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Kind
+  module WRONG_NUMBER_OF_ARGS
+    def self.error!(given:, expected:)
+      raise ArgumentError, "wrong number of arguments (given #{given}, expected #{expected})"
+    end
+  end
+end

--- a/lib/kind/dig.rb
+++ b/lib/kind/dig.rb
@@ -5,7 +5,7 @@ module Kind
     extend self
 
     def call(data, keys)
-      return unless keys.is_a?(::Array)
+      return unless keys.kind_of?(::Array)
 
       keys.reduce(data) do |memo, key|
         value = get(memo, key)

--- a/lib/kind/maybe/none.rb
+++ b/lib/kind/maybe/none.rb
@@ -23,7 +23,7 @@ module Kind
       alias_method :check, :map
 
       def try!(method_name = UNDEFINED, *args, &block)
-        Kind::Symbol[method_name] if UNDEFINED != method_name
+        KIND.of!(::Symbol, method_name)if UNDEFINED != method_name
 
         self
       end

--- a/lib/kind/maybe/result.rb
+++ b/lib/kind/maybe/result.rb
@@ -5,7 +5,7 @@ module Kind
     class Result
       attr_reader :value
 
-      Value = ->(arg) { arg.kind_of?(::Kind::Maybe::Result) ? arg.value : arg } # :nodoc:
+      Value = ->(arg) { arg.kind_of?(Maybe::Result) ? arg.value : arg } # :nodoc:
 
       def initialize(arg)
         @value = Value.(arg)

--- a/lib/kind/maybe/some.rb
+++ b/lib/kind/maybe/some.rb
@@ -58,7 +58,7 @@ module Kind
       private
 
         def __try_method__(method_name, args)
-          __try_block__(Kind::Symbol[method_name].to_proc, args)
+          __try_block__(KIND.of!(::Symbol, method_name).to_proc, args)
         end
 
         def __try_block__(block, args)

--- a/lib/kind/maybe/typed.rb
+++ b/lib/kind/maybe/typed.rb
@@ -12,7 +12,7 @@ module Kind
       def new(arg)
         value = Result::Value.(arg)
 
-        value.kind_of?(@kind) ? Maybe.some(value) : Maybe.none
+        @kind === value ? Maybe.some(value) : Maybe.none
       end
 
       alias_method :[], :new
@@ -22,7 +22,7 @@ module Kind
         def __call_before_expose_the_arg_in_a_block(arg)
           value = Result::Value.(arg)
 
-          value.kind_of?(@kind) ? value : Maybe.none
+          @kind === value ? value : Maybe.none
         end
     end
   end

--- a/lib/kind/maybe/wrappable.rb
+++ b/lib/kind/maybe/wrappable.rb
@@ -10,7 +10,7 @@ module Kind
 
             input = __call_before_expose_the_arg_in_a_block(arg)
 
-            input.kind_of?(Kind::Maybe::None) ? input : new(yield(input))
+            input.kind_of?(Maybe::None) ? input : new(yield(input))
           rescue StandardError => exception
             Maybe.__none__(exception)
           end

--- a/lib/kind/maybe/wrappable.rb
+++ b/lib/kind/maybe/wrappable.rb
@@ -3,8 +3,6 @@
 module Kind
   module Maybe
     module Wrappable
-      WRONG_NUMBER_OF_ARGS = 'wrong number of arguments (given 0, expected 1)'.freeze
-
       def wrap(arg = UNDEFINED)
         if block_given?
           begin
@@ -19,7 +17,7 @@ module Kind
         else
           return new(arg) if UNDEFINED != arg
 
-          raise ArgumentError, WRONG_NUMBER_OF_ARGS
+          WRONG_NUMBER_OF_ARGS.error!(given: 0, expected: 1)
         end
       end
 

--- a/lib/kind/try.rb
+++ b/lib/kind/try.rb
@@ -11,8 +11,6 @@ module Kind
     end
 
     def self.[](*args)
-      Array[args]
-
       method_name = args.shift
 
       ->(object) { call!(object, method_name, args) }

--- a/lib/kind/type_checker.rb
+++ b/lib/kind/type_checker.rb
@@ -44,7 +44,21 @@ module Kind
       KIND.null?(value) ? value : self[value]
     end
 
+    def maybe(value = UNDEFINED, &block)
+      return __maybe[value] if UNDEFINED != value && !block
+      return __maybe.wrap(&block) if UNDEFINED == value && block
+      return __maybe.wrap(value, &block) if UNDEFINED != value && block
+
+      __maybe
+    end
+
+    alias optional maybe
+
     private
+
+      def __maybe
+        @__maybe ||= Maybe::Typed.new(self)
+      end
 
       def __or_func
         @__or_func ||= ->(tc, fb, value) { tc === value ? value : tc.or_null(fb) }.curry[self]

--- a/lib/kind/version.rb
+++ b/lib/kind/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Kind
-  VERSION = '4.0.0'
+  VERSION = '4.1.0'
 end

--- a/test/kind/active_model/validation/kind_of_test.rb
+++ b/test/kind/active_model/validation/kind_of_test.rb
@@ -5,24 +5,26 @@ if ENV['ACTIVEMODEL_VERSION']
     class Person
       include ActiveModel::Validations
 
-      attr_reader :name, :age
+      attr_reader :name, :age, :alive
 
       validates :name, kind: { of: String }
       validates :age, kind: { of: Integer }
+      validates :alive, kind: { of: Kind::Boolean }
 
-      def initialize(name:, age:)
-        @name, @age = name, age
+      def initialize(name:, age:, alive:)
+        @name, @age, @alive = name, age, alive
       end
     end
 
     def test_the_validation_with_a_single_type
-      invalid_person = Person.new(name: 21, age: 'John')
+      invalid_person = Person.new(name: 21, age: 'John', alive: 0)
 
       refute_predicate(invalid_person, :valid?)
       assert_equal(['must be a kind of: String'], invalid_person.errors[:name])
       assert_equal(['must be a kind of: Integer'], invalid_person.errors[:age])
+      assert_equal(['must be a kind of: Boolean'], invalid_person.errors[:alive])
 
-      person = Person.new(name: 'John', age: 21)
+      person = Person.new(name: 'John', age: 21, alive: false)
 
       assert_predicate(person, :valid?)
     end
@@ -30,7 +32,7 @@ if ENV['ACTIVEMODEL_VERSION']
     class MyString < String; end
 
     def test_that_will_be_valid_when_checks_a_subclass
-      person = Person.new(name: MyString.new('John'), age: 21)
+      person = Person.new(name: MyString.new('John'), age: 21, alive: true)
 
       assert_predicate(person, :valid?)
     end

--- a/test/kind/active_model/validation/respond_to_test.rb
+++ b/test/kind/active_model/validation/respond_to_test.rb
@@ -18,7 +18,8 @@ if ENV['ACTIVEMODEL_VERSION']
       invalid_person = Person.new(handler: 21)
 
       refute_predicate(invalid_person, :valid?)
-      assert_equal(['must respond to the method `call`'], invalid_person.errors[:handler])
+
+      assert_equal(['must respond to the method: `call`'], invalid_person.errors[:handler])
 
       person = Person.new(handler: -> {})
 
@@ -38,7 +39,7 @@ if ENV['ACTIVEMODEL_VERSION']
 
       attr_reader :handler
 
-      validates! :handler, kind: { respond_to: :call }, allow_nil: true
+      validates! :handler, kind: { respond_to: [:call, :lambda?] }, allow_nil: true
 
       def initialize(handler:)
         @handler = handler
@@ -49,7 +50,7 @@ if ENV['ACTIVEMODEL_VERSION']
       assert_predicate(Task.new(handler: nil), :valid?)
       assert_predicate(Task.new(handler: -> {}), :valid?)
 
-      assert_raises_kind_error('handler must respond to the method `call`') do
+      assert_raises_kind_error('handler must respond to the methods: `call`, `lambda?`') do
         Task.new(handler: 42).valid?
       end
     end

--- a/test/kind/maybe_test.rb
+++ b/test/kind/maybe_test.rb
@@ -646,6 +646,10 @@ class Kind::MaybeTest < Minitest::Test
     assert 'John Doe' == person_name.(first_name: 'Rodrigo')
 
     assert 'Rodrigo Serradura' == person_name.(first_name: 'Rodrigo', last_name: 'Serradura')
+
+    # --
+
+    Kind::Maybe(Array).wrap([1]).check(&:empty?).none?
   end
 
   def test_that_the_wrap_method_of_a_typed_maybe_verifies_if_the_block_arg_has_the_right_kind

--- a/test/kind/validator/default_strategy_test.rb
+++ b/test/kind/validator/default_strategy_test.rb
@@ -7,22 +7,24 @@ if ENV['ACTIVEMODEL_VERSION']
     class Person
       include ActiveModel::Validations
 
-      attr_reader :name
+      attr_reader :name, :alive
 
       validates :name, kind: String
+      validates :alive, kind: Kind::Boolean
 
-      def initialize(name:)
-        @name = name
+      def initialize(name:, alive:)
+        @name, @alive = name, alive
       end
     end
 
     def test_the_default_strategy
-      invalid_person = Person.new(name: 21)
+      invalid_person = Person.new(name: 21, alive: nil)
 
       refute_predicate(invalid_person, :valid?)
       assert_equal(['must be a kind of: String'], invalid_person.errors[:name])
+      assert_equal(['must be a kind of: Boolean'], invalid_person.errors[:alive])
 
-      person = Person.new(name: MyString.new('John'))
+      person = Person.new(name: MyString.new('John'), alive: true)
 
       assert_predicate(person, :valid?)
     end
@@ -33,17 +35,18 @@ if ENV['ACTIVEMODEL_VERSION']
       Kind::Validator.default_strategy = 'instance_of'
 
       [
-        Person.new(name: 21),
-        Person.new(name: MyString.new('John'))
+        Person.new(name: 21, alive: nil),
+        Person.new(name: MyString.new('John'), alive: 0)
       ].each do |person|
         refute_predicate(person, :valid?)
         assert_equal(['must be an instance of: String'], person.errors[:name])
+        assert_equal(['must be an instance of: Boolean'], person.errors[:alive])
       end
 
       Kind::Validator.default_strategy = :kind_of
 
       [
-        Person.new(name: MyString.new('John'))
+        Person.new(name: MyString.new('John'), alive: false)
       ].each { |person| assert_predicate(person, :valid?) }
 
       Kind::Validator.default_strategy = default_strategy


### PR DESCRIPTION
### Added

- Make `Kind::Maybe::Typed` verify the kind of the value via `===`, because of this, now is possible to use type checkers in typed Maybes.
  ```ruby
  Kind::Maybe(Kind::Boolean).wrap(nil).value_or(false)  # false

  Kind::Maybe(Kind::Boolean).wrap(true).value_or(false) # true
  ```

- Add `Kind::<Type>.maybe` and `Kind::<Type>.optional`. This method returns a typed Maybe with the expected kind when it is invoked without arguments. But, if it receives arguments, it will behave like the `Kind::Maybe.wrap` method. e.g.
  ```ruby
  Kind::Integer.maybe #<Kind::Maybe::Typed:0x0000... @kind=Kind::Integer>

  Kind::Integer.maybe(0).some?               # true
  Kind::Integer.maybe { 1 }.some?            # true
  Kind::Integer.maybe(2) { |n| n * 2 }.some? # true

  Kind::Integer.maybe { 2 / 0 }.none?          # true
  Kind::Integer.maybe(2) { |n| n / 0 }.none?   # true
  Kind::Integer.maybe('2') { |n| n * n }.none? # true
  ```

- Make the `:respond_to` kind validation verify by one or multiple methods. e.g.
  ```ruby
  validates :params, kind: { respond_to: [:[], :values_at] }
  ```

- Make the `:of` kind validation verify the expected value kind using `===`, because of this, now is possible to use type checkers as expected kinds. e.g.
  ```ruby
  validates :alive, kind: Kind::Boolean
  ```