### PR TITLE
Improve basic and core modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ This project follows [semver 2.0.0](http://semver.org/spec/v2.0.0.html) and the 
 
 - [Unreleased](#unreleased)
   - [Added](#added)
+  - [Deprecated](#deprecated)
 - [5.1.0 (2021-02-23)](#510-2021-02-23)
   - [Added](#added-1)
-  - [Deprecated](#deprecated)
+  - [Deprecated](#deprecated-1)
 - [5.0.0 (2021-02-22)](#500-2021-02-22)
   - [Breaking Changes](#breaking-changes)
   - [Removed](#removed)
@@ -14,7 +15,7 @@ This project follows [semver 2.0.0](http://semver.org/spec/v2.0.0.html) and the 
   - [Added](#added-2)
 - [4.0.0 (2021-02-22)](#400-2021-02-22)
   - [Added](#added-3)
-  - [Deprecated](#deprecated-1)
+  - [Deprecated](#deprecated-2)
   - [Fixed](#fixed)
 - [3.1.0 (2020-07-08)](#310-2020-07-08)
   - [Added](#added-4)
@@ -127,11 +128,13 @@ This project follows [semver 2.0.0](http://semver.org/spec/v2.0.0.html) and the 
   hash_or_nil === nil # true
   ```
 
-* [#46](https://github.com/serradura/kind/pull/46) - Add `Kind::NotNil`. This module was added to perform a strict verification where the given value will be returned if it is not nil, and if not, a `Kind::Error` will be raised. e.g.
+* [#46](https://github.com/serradura/kind/pull/46), [#47](https://github.com/serradura/kind/pull/47) - Add `Kind::NotNil`. This module was added to perform a strict verification where the given value will be returned if it is not nil, and if not, a `Kind::Error` will be raised. e.g.
   ```ruby
   Kind::NotNil[1]   # 1
 
   Kind::NotNil[nil] # Kind::Error (expected to not be nil)
+
+  Kind::NotNil[nil, label: 'Foo#bar'] # Kind::Error (Foo#bar: expected to not be nil)
   ```
 
 * [#46](https://github.com/serradura/kind/pull/46) - Add `Kind::RespondTo` to create objects that know how to verify if a given object implements one or more expected methods.
@@ -323,6 +326,16 @@ This project follows [semver 2.0.0](http://semver.org/spec/v2.0.0.html) and the 
 * [#46](https://github.com/serradura/kind/pull/46) - Add `Kind::Try.presence` and improve the input/output handling of `Kind::Try.call`.
 
 * [#46](https://github.com/serradura/kind/pull/46) - Add `Kind::Dig.presence` and improve the input/output handling of `Kind::Dig.call`.
+
+* [#47](https://github.com/serradura/kind/pull/47) - Add `Kind.is!`
+
+* [#47](https://github.com/serradura/kind/pull/47) - Create aliases to the methods `Kind.of` (`Kind.of!`) and `Kind.respond_to` (`Kind.respond_to!`)
+
+* [#47](https://github.com/serradura/kind/pull/47) - Add `Kind[]` as the `Kind::Of()` substitute.
+
+### Deprecated
+
+* [#47](https://github.com/serradura/kind/pull/47) - Deprecate `Kind.is` and `Kind::Of()`.
 
 
 [⬆️ &nbsp;Back to Top](#changelog-)

--- a/lib/kind/action.rb
+++ b/lib/kind/action.rb
@@ -30,7 +30,7 @@ module Kind
 
     module Macros
       def require_action_contract!
-        return self if Kind.is(Behavior, self)
+        return self if Kind.is?(Behavior, self)
 
         public_methods = self.public_instance_methods - Object.new.methods
 

--- a/lib/kind/basic.rb
+++ b/lib/kind/basic.rb
@@ -45,21 +45,24 @@ module Kind
     KIND.interface?(method_names, value)
   end
 
-  def respond_to(value, *method_names)
-    method_names.each { |method_name| KIND.respond_to!(method_name, value) }
-
-    value
-  end
-
-  def of_module_or_class(value)
-    KIND.of_module_or_class!(value)
-  end
-
   def of(kind, value, label: nil)
     return value if kind === value
 
     KIND.error!(kind.name, value, label)
   end
+
+  alias_method :of!, :of
+
+  def of_module_or_class(value)
+    KIND.of_module_or_class!(value)
+  end
+
+  def respond_to(value, *method_names)
+    method_names.each { |method_name| KIND.respond_to!(method_name, value) }
+
+    value
+  end
+  alias_method :respond_to!, :respond_to
 
   def value(kind, value, default:)
     KIND.value(kind, value, of(kind, default))

--- a/lib/kind/basic.rb
+++ b/lib/kind/basic.rb
@@ -12,7 +12,20 @@ module Kind
     KIND.is?(kind, arg)
   end
 
-  alias is is?
+  def is(*args)
+    warn '[DEPRECATION] Kind.is will behave like Kind.is! in the next major release; ' \
+        'use Kind.is? instead.'
+
+    is?(*args)
+  end
+
+  def is!(kind, arg, label: nil)
+    return arg if KIND.is?(kind, arg)
+
+    label_text = label ? "#{label}: " : ''
+
+    raise Kind::Error.new("#{label_text}#{arg} expected to be a #{kind}")
+  end
 
   def of?(kind, *args)
     KIND.of?(kind, args)

--- a/lib/kind/basic/error.rb
+++ b/lib/kind/basic/error.rb
@@ -18,7 +18,7 @@ module Kind
         # raise Kind::Error, "some message"
         super(arg)
       else
-        label_text = label ? "#{label}: " : label
+        label_text = label ? "#{label}: " : ''
 
         super("#{label_text}#{object.inspect} expected to be a kind of #{arg}")
       end

--- a/lib/kind/basic/kind.rb
+++ b/lib/kind/basic/kind.rb
@@ -2,64 +2,68 @@
 
 module Kind
   module KIND
-    def self.null?(value) # :nodoc:
+    extend self
+
+    def null?(value) # :nodoc:
       value.nil? || Undefined == value
     end
 
-    def self.of?(kind, values) # :nodoc:
+    def of?(kind, values) # :nodoc:
       of_kind = -> value { kind === value }
 
       values.empty? ? of_kind : values.all?(&of_kind)
     end
 
-    def self.of!(kind, value, kind_name = nil) # :nodoc:
+    def of!(kind, value, kind_name = nil) # :nodoc:
       return value if kind === value
 
       error!(kind_name || kind.name, value)
     end
 
-    def self.error!(kind_name, value, label = nil) # :nodoc:
+    def error!(kind_name, value, label = nil) # :nodoc:
       raise Error.new(kind_name, value, label: label)
     end
 
-    def self.of_class?(value) # :nodoc:
+    def of_class?(value) # :nodoc:
       value.kind_of?(::Class)
     end
 
-    def self.of_module?(value) # :nodoc:
+    def of_module?(value) # :nodoc:
       ::Module == value || (value.kind_of?(::Module) && !of_class?(value))
     end
 
-    def self.of_module_or_class!(value) # :nodoc:
+    def of_module_or_class!(value) # :nodoc:
       of!(::Module, value, 'Module/Class')
     end
 
-    def self.respond_to!(method_name, value) # :nodoc:
+    def respond_to!(method_name, value) # :nodoc:
       return value if value.respond_to?(method_name)
 
       raise Error.new("expected #{value} to respond to :#{method_name}")
     end
 
-    def self.interface?(method_names, value) # :nodoc:
+    def interface?(method_names, value) # :nodoc:
       method_names.all? { |method_name| value.respond_to?(method_name) }
     end
 
-    def self.is?(expected, value) # :nodoc:
-      is!(of_module_or_class!(expected), value)
-    end
-
-    def self.is!(expected_kind, value) # :nodoc:
-      kind = of_module_or_class!(value)
-
-      if of_class?(kind)
-        kind <= expected_kind || expected_kind == ::Class
-      else
-        kind == expected_kind || kind.kind_of?(expected_kind)
-      end
-    end
-
-    def self.value(kind, arg, default) # :nodoc:
+    def value(kind, arg, default) # :nodoc:
       kind === arg ? arg : default
     end
+
+    def is?(expected, value) # :nodoc:
+      is(of_module_or_class!(expected), value)
+    end
+
+    private
+
+      def is(expected_kind, value) # :nodoc:
+        kind = of_module_or_class!(value)
+
+        if of_class?(kind)
+          kind <= expected_kind || expected_kind == ::Class
+        else
+          kind == expected_kind || kind.kind_of?(expected_kind)
+        end
+      end
   end
 end

--- a/lib/kind/core/not_nil.rb
+++ b/lib/kind/core/not_nil.rb
@@ -2,10 +2,12 @@
 
 module Kind
   module NotNil
-    def self.[](value)
+    def self.[](value, label: nil)
       return value unless value.nil?
 
-      raise Error.new('expected to not be nil')
+      label_text = label ? "#{label}: " : ''
+
+      raise Error.new("#{label_text}expected to not be nil")
     end
   end
 end

--- a/lib/kind/core/type_checker.rb
+++ b/lib/kind/core/type_checker.rb
@@ -93,8 +93,16 @@ module Kind
     private_constant :ResolveKindName
   end
 
-  # Kind::Ok()
-  def self.Of(kind, opt = Empty::HASH)
+  # Kind[]
+  def self.[](kind, opt = Empty::HASH)
     TypeChecker::Object.new(kind, opt)
+  end
+
+  # Kind::Of()
+  def self.Of(*args)
+    warn '[DEPRECATION] Kind::Of() is deprecated; use Kind[] instead.' \
+        'It will be removed on next major release.'
+
+    self[*args]
   end
 end

--- a/lib/kind/function.rb
+++ b/lib/kind/function.rb
@@ -23,7 +23,7 @@ module Kind
     end
 
     def require_function_contract!
-      return self if Kind.is(Behavior, self)
+      return self if Kind.is?(Behavior, self)
 
       KIND.respond_to!(:call, self).extend(Behavior)
 

--- a/lib/kind/functional.rb
+++ b/lib/kind/functional.rb
@@ -69,7 +69,7 @@ module Kind
       include DependencyInjection
 
       def require_functional_contract!
-        return self if Kind.is(Behavior, self)
+        return self if Kind.is?(Behavior, self)
 
         public_methods = self.public_instance_methods - Object.new.methods
 

--- a/test/kind/basic_test.rb
+++ b/test/kind/basic_test.rb
@@ -75,6 +75,36 @@ class Kind::KindTest < Minitest::Test
     ) { Kind.is!(Class, Enumerable, label: 'Foo#bar') }
   end
 
+  def test_Kind_of
+    assert_equal([], Kind.of(Array, []))
+    assert_equal({}, Kind.of(Enumerable, {}))
+
+    assert_raises_with_message(
+      Kind::Error,
+      'nil expected to be a kind of Array'
+    ) { Kind.of(Array, nil) }
+
+    assert_raises_with_message(
+      Kind::Error,
+      'Foo#bar: nil expected to be a kind of Array'
+    ) { Kind.of(Array, nil, label: 'Foo#bar') }
+  end
+
+  def test_Kind_of!
+    assert_equal([], Kind.of!(Array, []))
+    assert_equal({}, Kind.of!(Enumerable, {}))
+
+    assert_raises_with_message(
+      Kind::Error,
+      'nil expected to be a kind of Array'
+    ) { Kind.of!(Array, nil) }
+
+    assert_raises_with_message(
+      Kind::Error,
+      'Foo#bar: nil expected to be a kind of Array'
+    ) { Kind.of!(Array, nil, label: 'Foo#bar') }
+  end
+
   def test_Kind_of?
     # FACT: Can check one instance
     assert Kind.of?(Array, [])
@@ -141,6 +171,23 @@ class Kind::KindTest < Minitest::Test
       Kind::Error,
       'expected 2 to respond to :upcase'
     ) { Kind.respond_to(2, :to_s, :upcase) }
+  end
+
+  def test_Kind_respond_to!
+    assert_equal('', Kind.respond_to!('', :upcase))
+    assert_equal('', Kind.respond_to!('', :upcase, :strip))
+
+    # -
+
+    assert_raises_with_message(
+      Kind::Error,
+      'expected 1 to respond to :upcase'
+    ) { Kind.respond_to!(1, :upcase) }
+
+    assert_raises_with_message(
+      Kind::Error,
+      'expected 2 to respond to :upcase'
+    ) { Kind.respond_to!(2, :to_s, :upcase) }
   end
 
   def test_Kind_of_module_or_class

--- a/test/kind/basic_test.rb
+++ b/test/kind/basic_test.rb
@@ -56,6 +56,25 @@ class Kind::KindTest < Minitest::Test
     ) { Kind.is(String, '2') }
   end
 
+  def test_Kind_is!
+    assert Array == Kind.is!(Class, Array)
+    assert Array == Kind.is!(Array, Array)
+
+    assert Array == Kind.is!(Enumerable, Array)
+    assert Enumerable == Kind.is!(Enumerable, Enumerable)
+    assert Enumerable == Kind.is!(Module, Enumerable)
+
+    assert_raises_with_message(
+      Kind::Error,
+      'Enumerable expected to be a Class'
+    ) { Kind.is!(Class, Enumerable) }
+
+    assert_raises_with_message(
+      Kind::Error,
+      'Foo#bar: Enumerable expected to be a Class'
+    ) { Kind.is!(Class, Enumerable, label: 'Foo#bar') }
+  end
+
   def test_Kind_of?
     # FACT: Can check one instance
     assert Kind.of?(Array, [])

--- a/test/kind/core/not_nil_test.rb
+++ b/test/kind/core/not_nil_test.rb
@@ -8,5 +8,10 @@ class Kind::NoteNilTest < Minitest::Test
       Kind::Error,
       'expected to not be nil'
     ) { Kind::NotNil[nil] }
+
+    assert_raises_with_message(
+      Kind::Error,
+      'Foo#bar: expected to not be nil'
+    ) { Kind::NotNil[nil, label: 'Foo#bar'] }
   end
 end

--- a/test/kind/core/type_checkers_test.rb
+++ b/test/kind/core/type_checkers_test.rb
@@ -344,15 +344,15 @@ class Kind::TypeCheckersTest < Minitest::Test
     assert_predicate(Kind::Set.value_or_empty(1), :frozen?)
   end
 
-  def test_Kind_Of
-    kind_symbol1 = Kind::Of(Symbol)
+  def test_Kind_brackets
+    kind_symbol1 = Kind[Symbol]
 
     assert_instance_of(Kind::TypeChecker::Object, kind_symbol1)
     assert_equal('Symbol', kind_symbol1.name)
 
     # -
 
-    kind_symbol2 = Kind::Of(Symbol, name: 'MySymbol')
+    kind_symbol2 = Kind[Symbol, name: 'MySymbol']
 
     assert_instance_of(Kind::TypeChecker::Object, kind_symbol2)
     assert_equal('MySymbol', kind_symbol2.name)
@@ -360,5 +360,11 @@ class Kind::TypeCheckersTest < Minitest::Test
     # -
 
     refute_same(kind_symbol1, kind_symbol2)
+  end
+
+  def test_Kind_Of
+    assert Kind[Symbol].kind == Kind::Of(Symbol).kind
+    assert Kind[Symbol].name == Kind::Of(Symbol).name
+    assert Kind[Symbol].class == Kind::Of(Symbol).class
   end
 end


### PR DESCRIPTION
### Added

- Add `Kind.is!`

- Create aliases to the methods `Kind.of` (`Kind.of!`) and `Kind.respond_to` (`Kind.respond_to!`)

- Add `Kind[]` as the `Kind::Of()` substitute.

- Add label option into `Kind::NotNil[]`

### Deprecated

- Deprecate `Kind.is` and `Kind::Of()`.