### PR TITLE
Add `Kind::<Type>.empty_or`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -338,6 +338,8 @@ This project follows [semver 2.0.0](http://semver.org/spec/v2.0.0.html) and the 
 
 * [#49](https://github.com/serradura/kind/pull/49) - Add `Kind::Undefined.empty?`
 
+* [#50](https://github.com/serradura/kind/pull/50) - Add `Kind::<Type>.empty_or` as an alias of `Kind::<Type>.value_or_empty`
+
 ### Deprecated
 
 * [#47](https://github.com/serradura/kind/pull/47) - Deprecate `Kind.is` and `Kind::Of()`.

--- a/lib/kind/core/objects/ruby/array.rb
+++ b/lib/kind/core/objects/ruby/array.rb
@@ -9,6 +9,8 @@ module Kind
     def value_or_empty(arg)
       KIND.value(self, arg, Empty::ARRAY)
     end
+
+    alias empty_or value_or_empty
   end
 
   def self.Array?(*values)

--- a/lib/kind/core/objects/ruby/hash.rb
+++ b/lib/kind/core/objects/ruby/hash.rb
@@ -9,6 +9,8 @@ module Kind
     def value_or_empty(arg)
       KIND.value(self, arg, Empty::HASH)
     end
+
+    alias empty_or value_or_empty
   end
 
   def self.Hash?(*values)

--- a/lib/kind/core/objects/ruby/string.rb
+++ b/lib/kind/core/objects/ruby/string.rb
@@ -9,6 +9,8 @@ module Kind
     def value_or_empty(arg)
       KIND.value(self, arg, Empty::STRING)
     end
+
+    alias empty_or value_or_empty
   end
 
   def self.String?(*values)

--- a/lib/kind/core/objects/stdlib/set.rb
+++ b/lib/kind/core/objects/stdlib/set.rb
@@ -9,6 +9,8 @@ module Kind
     def value_or_empty(arg)
       KIND.value(self, arg, Empty::SET)
     end
+
+    alias empty_or value_or_empty
   end
 
   def self.Set?(*values)

--- a/test/kind/core/objects_test.rb
+++ b/test/kind/core/objects_test.rb
@@ -17,6 +17,8 @@ class Kind::ObjectsTest < Minitest::Test
     assert_predicate(Kind::Array.value_or_empty(1), :empty?)
     assert_predicate(Kind::Array.value_or_empty(1), :frozen?)
 
+    assert_equal(Kind::Array.value_or_empty(nil), Kind::Array.empty_or(nil))
+
     union_type = Kind::Array | Kind::Hash
     assert union_type === []
     assert union_type === {}
@@ -98,6 +100,8 @@ class Kind::ObjectsTest < Minitest::Test
     assert_kind_of(::Hash, Kind::Hash.value_or_empty(1))
     assert_predicate(Kind::Hash.value_or_empty(1), :empty?)
     assert_predicate(Kind::Hash.value_or_empty(1), :frozen?)
+
+    assert_equal(Kind::Hash.value_or_empty(nil), Kind::Hash.empty_or(nil))
 
     # == Kind::Integer ==
 
@@ -248,6 +252,8 @@ class Kind::ObjectsTest < Minitest::Test
     assert_predicate(Kind::String.value_or_empty(1), :empty?)
     assert_predicate(Kind::String.value_or_empty(1), :frozen?)
 
+    assert_equal(Kind::String.value_or_empty(nil), Kind::String.empty_or(nil))
+
     # == Kind::Struct ==
 
     struct = Struct.new(:a).new(1)
@@ -342,6 +348,8 @@ class Kind::ObjectsTest < Minitest::Test
     assert_kind_of(::Set, Kind::Set.value_or_empty([1]))
     assert_predicate(Kind::Set.value_or_empty(1), :empty?)
     assert_predicate(Kind::Set.value_or_empty(1), :frozen?)
+
+    assert_equal(Kind::Set.value_or_empty(nil), Kind::Set.empty_or(nil))
   end
 
   def test_Kind_brackets


### PR DESCRIPTION
### Added

- Add `Kind::<Type>.empty_or` as an alias of `Kind::<Type>.value_or_empty`