### PR TITLE
Improve Kind::Validator and Kind::Enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 This project follows [semver 2.0.0](http://semver.org/spec/v2.0.0.html) and the recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 - [Unreleased](#unreleased)
+- [5.2.0 (2021-03-17)](#520-2021-03-17)
   - [Added](#added)
   - [Deprecated](#deprecated)
   - [Changes](#changes)
@@ -79,6 +80,9 @@ This project follows [semver 2.0.0](http://semver.org/spec/v2.0.0.html) and the 
 ### Removed
 ### Fixed
 -->
+
+5.2.0 (2021-03-17)
+------------------
 
 ### Added
 
@@ -364,6 +368,38 @@ This project follows [semver 2.0.0](http://semver.org/spec/v2.0.0.html) and the 
   * `kind/result`
   * `kind/try`
   * `kind/validator`
+
+* [#52](https://github.com/serradura/kind/pull/52) - Improve `Kind::Validator`, now will be possible to make use of `lambdas` or objects that responds to `.===` and `.name` to perform a kind validation. e.g.
+  ```ruby
+  class User
+    include ActiveModel::Validations
+
+    attr_reader :name, :bool
+
+    FilledString = ->(value) { value.kind_of?(String) && !value.empty? }
+
+    Bool = Object.new
+    def Bool.===(value)
+      value == true || value == false
+    end
+    def Bool.name; 'Bool'; end
+
+    validates :name, kind: FilledString
+    validates :bool, kind: Bool
+
+    def initialize(name:, bool:)
+      @name, @bool = name, bool
+    end
+  end
+
+  user = User.new(name: '', bool: 1)
+
+  user.valid?        # true
+  user.errors[:name] # ['invalid kind']
+  user.errors[:bool] # ['must be a kind of Bool']
+
+  User.new(name: 'Serradura', bool: true).valid? # true
+  ```
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -401,6 +401,8 @@ This project follows [semver 2.0.0](http://semver.org/spec/v2.0.0.html) and the 
   User.new(name: 'Serradura', bool: true).valid? # true
   ```
 
+* [#52](https://github.com/serradura/kind/pull/52) - Add `Kind::Enum.===`.
+
 ### Deprecated
 
 * [#47](https://github.com/serradura/kind/pull/47) - Deprecate `Kind.is` and `Kind::Of()`.

--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ One of the goals of this project is to do simple type checking like `"some strin
 
 Version    | Documentation
 ---------- | -------------
-unreleased | https://github.com/serradura/u-case/blob/main/README.md
-5.1.0      | https://github.com/serradura/u-case/blob/v5.x/README.md
-4.1.0      | https://github.com/serradura/u-case/blob/v4.x/README.md
-3.1.0      | https://github.com/serradura/u-case/blob/v3.x/README.md
-2.3.0      | https://github.com/serradura/u-case/blob/v2.x/README.md
-1.9.0      | https://github.com/serradura/u-case/blob/v1.x/README.md
+unreleased | https://github.com/serradura/kind/blob/main/README.md
+5.2.0      | https://github.com/serradura/kind/blob/v5.x/README.md
+4.1.0      | https://github.com/serradura/kind/blob/v4.x/README.md
+3.1.0      | https://github.com/serradura/kind/blob/v3.x/README.md
+2.3.0      | https://github.com/serradura/kind/blob/v2.x/README.md
+1.9.0      | https://github.com/serradura/kind/blob/v1.x/README.md
 
 ## Table of Contents <!-- omit in toc -->
 - [Compatibility](#compatibility)
@@ -59,7 +59,7 @@ unreleased | https://github.com/serradura/u-case/blob/main/README.md
   - [Kind::\<Type\>.value()](#kindtypevalue-1)
   - [Kind::\<Type\>.maybe](#kindtypemaybe)
   - [Kind::\<Type\>?](#kindtype-2)
-  - [Kind::{Array,Hash,String,Set}.value_or_empty()](#kindarrayhashstringsetvalue_or_empty)
+  - [Kind::{Array,Hash,String,Set}.empty_or()](#kindarrayhashstringsetempty_or)
   - [List of all type handlers](#list-of-all-type-handlers)
     - [Core](#core)
     - [Stdlib](#stdlib)
@@ -120,10 +120,10 @@ unreleased | https://github.com/serradura/u-case/blob/main/README.md
 
 ## Compatibility
 
-| u-case         | branch  | ruby     |  activemodel   |
+| kind           | branch  | ruby     |  activemodel   |
 | -------------- | ------- | -------- | -------------- |
 | unreleased     | main    | >= 2.1.0 | >= 3.2, <= 6.1 |
-| 5.1.0          | v5.x    | >= 2.1.0 | >= 3.2, <= 6.1 |
+| 5.2.0          | v5.x    | >= 2.1.0 | >= 3.2, <= 6.1 |
 | 4.1.0          | v4.x    | >= 2.2.0 | >= 3.2, <= 6.1 |
 | 3.1.0          | v3.x    | >= 2.2.0 | >= 3.2, <= 6.1 |
 | 2.3.0          | v2.x    | >= 2.2.0 | >= 3.2, <= 6.0 |
@@ -328,12 +328,12 @@ collection.select(&Kind::Enumerable?) # [{:number=>1}, {:number=>3}, [:number, 5
 
 [⬆️ &nbsp;Back to Top](#table-of-contents-)
 
-### Kind::{Array,Hash,String,Set}.value_or_empty()
+### Kind::{Array,Hash,String,Set}.empty_or()
 
 This method is available for some type handlers (`Kind::Array`, `Kind::Hash`, `Kind::String`, `Kind::Set`), and it will return an empty frozen value if the given one hasn't the expected kind.
 ```ruby
-Kind::Array.value_or_empty({})         # []
-Kind::Array.value_or_empty({}).frozen? # true
+Kind::Array.empty_or({})         # []
+Kind::Array.empty_or({}).frozen? # true
 ```
 
 [⬆️ &nbsp;Back to Top](#table-of-contents-)
@@ -528,7 +528,7 @@ PositiveInteger.maybe(2).value_or(1) # 2
 
 #### Kind::<Type> object
 
-The idea here is to create a type handler inside of the `Kind` namespace, so to do this, you will only need to use pure Ruby. e.g:
+The idea here is to create a type handler inside of the `Kind` namespace and to do this you will only need to use pure Ruby. e.g:
 
 ```ruby
 class User

--- a/lib/kind/enum/methods.rb
+++ b/lib/kind/enum/methods.rb
@@ -12,6 +12,10 @@ module Kind
       ENUM__ITEMS
     end
 
+    def ===(arg)
+      ENUM__ITEMS.any? { |item| item === arg }
+    end
+
     def refs
       ENUM__REFS.to_a
     end

--- a/lib/kind/validator.rb
+++ b/lib/kind/validator.rb
@@ -77,11 +77,15 @@ class KindValidator < ActiveModel::EachValidator
     end
 
     def kind_of(expected, value)
-      types = Array(expected)
+      if ::Array === expected
+        return if expected.any? { |type| type === value }
 
-      return if types.any? { |type| type === value }
+        "must be a kind of #{expected.map { |type| type.name }.join(', ')}"
+      else
+        return if expected === value
 
-      "must be a kind of: #{types.map { |type| type.name }.join(', ')}"
+        expected.respond_to?(:name) ? "must be a kind of #{expected.name}" : 'invalid kind'
+      end
     end
 
     CLASS_OR_MODULE = 'Class/Module'.freeze
@@ -128,13 +132,13 @@ class KindValidator < ActiveModel::EachValidator
 
       return if types.any? { |type| value.instance_of?(type) }
 
-      "must be an instance of: #{types.map { |klass| klass.name }.join(', ')}"
+      "must be an instance of #{types.map { |klass| klass.name }.join(', ')}"
     end
 
     def array_with(expected, value)
       return if value.kind_of?(::Array) && !value.empty? && (value - Kind.of!(::Array, expected)).empty?
 
-      "must be an array with: #{expected.join(', ')}"
+      "must be an array with #{expected.join(', ')}"
     end
 
     def array_of(expected, value)
@@ -142,6 +146,6 @@ class KindValidator < ActiveModel::EachValidator
 
       return if value.kind_of?(::Array) && !value.empty? && value.all? { |val| types.any? { |type| type === val } }
 
-      "must be an array of: #{types.map { |klass| klass.name }.join(', ')}"
+      "must be an array of #{types.map { |klass| klass.name }.join(', ')}"
     end
 end

--- a/lib/kind/version.rb
+++ b/lib/kind/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Kind
-  VERSION = '5.1.0'
+  VERSION = '5.2.0'
 end

--- a/test/kind/enum_test.rb
+++ b/test/kind/enum_test.rb
@@ -33,6 +33,7 @@ class Kind::EnumTest < Minitest::Test
     )
 
     [:low, :medium, :high, 'low', 'medium', 'high', 0, 1, 2].each do |key|
+      assert Level1 === key
       assert Level1.ref?(key)
     end
 
@@ -137,6 +138,7 @@ class Kind::EnumTest < Minitest::Test
     )
 
     [:low, :medium, :high, 'low', 'medium', 'high', 0, 1, 2].each do |key|
+      assert Level2 === key
       assert Level2.ref?(key)
     end
 
@@ -228,6 +230,7 @@ class Kind::EnumTest < Minitest::Test
     )
 
     [:banana, :Orange, 'banana', 'Orange', 'bANANA', 'orangE'].each do |key|
+      assert Fruits === key
       assert Fruits.ref?(key)
     end
 

--- a/test/kind/validator/array_of_test.rb
+++ b/test/kind/validator/array_of_test.rb
@@ -21,7 +21,7 @@ if ENV['ACTIVEMODEL_VERSION']
         Person.new(values: [])
       ].each do |person|
         refute_predicate(person, :valid?)
-        assert_equal(['must be an array of: String'], person.errors[:values])
+        assert_equal(['must be an array of String'], person.errors[:values])
       end
 
       person = Person.new(values: %w[a b c])
@@ -65,7 +65,7 @@ if ENV['ACTIVEMODEL_VERSION']
         Job.new(ids: [])
       ].each do |job|
         refute_predicate(job, :valid?)
-        assert_equal(['must be an array of: Integer, Float'], job.errors[:ids])
+        assert_equal(['must be an array of Integer, Float'], job.errors[:ids])
       end
     end
 
@@ -96,7 +96,7 @@ if ENV['ACTIVEMODEL_VERSION']
         Task.new(statuses: []),
         Task.new(statuses: [1])
       ].each do |task|
-        assert_raises_kind_error('statuses must be an array of: String') do
+        assert_raises_kind_error('statuses must be an array of String') do
           task.valid?
         end
       end

--- a/test/kind/validator/array_with_test.rb
+++ b/test/kind/validator/array_with_test.rb
@@ -21,7 +21,7 @@ if ENV['ACTIVEMODEL_VERSION']
         Person.new(values: [1, 2, 3, 5])
       ].each do |person|
         refute_predicate(person, :valid?)
-        assert_equal(['must be an array with: 1, 2, 3'], person.errors[:values])
+        assert_equal(['must be an array with 1, 2, 3'], person.errors[:values])
       end
 
       person = Person.new(values: [1])
@@ -62,7 +62,7 @@ if ENV['ACTIVEMODEL_VERSION']
         Task.new(values: []),
         Task.new(values: [4])
       ].each do |task|
-        assert_raises_kind_error('values must be an array with: 1, 2, 3') do
+        assert_raises_kind_error('values must be an array with 1, 2, 3') do
           task.valid?
         end
       end

--- a/test/kind/validator/default_strategy_test.rb
+++ b/test/kind/validator/default_strategy_test.rb
@@ -21,8 +21,8 @@ if ENV['ACTIVEMODEL_VERSION']
       invalid_person = Person.new(name: 21, alive: nil)
 
       refute_predicate(invalid_person, :valid?)
-      assert_equal(['must be a kind of: String'], invalid_person.errors[:name])
-      assert_equal(['must be a kind of: Boolean'], invalid_person.errors[:alive])
+      assert_equal(['must be a kind of String'], invalid_person.errors[:name])
+      assert_equal(['must be a kind of Boolean'], invalid_person.errors[:alive])
 
       person = Person.new(name: MyString.new('John'), alive: true)
 
@@ -39,8 +39,8 @@ if ENV['ACTIVEMODEL_VERSION']
         Person.new(name: MyString.new('John'), alive: 0)
       ].each do |person|
         refute_predicate(person, :valid?)
-        assert_equal(['must be an instance of: String'], person.errors[:name])
-        assert_equal(['must be an instance of: Boolean'], person.errors[:alive])
+        assert_equal(['must be an instance of String'], person.errors[:name])
+        assert_equal(['must be an instance of Boolean'], person.errors[:alive])
       end
 
       Kind::Validator.default_strategy = :kind_of
@@ -70,7 +70,7 @@ if ENV['ACTIVEMODEL_VERSION']
       invalid_user = User.new(name: 21)
 
       refute_predicate(invalid_user, :valid?)
-      assert_equal(['must be a kind of: String, Symbol'], invalid_user.errors[:name])
+      assert_equal(['must be a kind of String, Symbol'], invalid_user.errors[:name])
 
       [
         User.new(name: :John),

--- a/test/kind/validator/instance_of_test.rb
+++ b/test/kind/validator/instance_of_test.rb
@@ -19,8 +19,8 @@ if ENV['ACTIVEMODEL_VERSION']
       invalid_person = Person.new(name: 21.0, age: 'John')
 
       refute_predicate(invalid_person, :valid?)
-      assert_equal(['must be an instance of: String'], invalid_person.errors[:name])
-      assert_equal(['must be an instance of: Float'], invalid_person.errors[:age])
+      assert_equal(['must be an instance of String'], invalid_person.errors[:name])
+      assert_equal(['must be an instance of Float'], invalid_person.errors[:age])
 
       person = Person.new(name: 'John', age: 21.0)
 
@@ -34,7 +34,7 @@ if ENV['ACTIVEMODEL_VERSION']
 
       refute_predicate(person, :valid?)
 
-      assert_equal(['must be an instance of: String'], person.errors[:name])
+      assert_equal(['must be an instance of String'], person.errors[:name])
     end
 
     # ---
@@ -61,7 +61,7 @@ if ENV['ACTIVEMODEL_VERSION']
       assert_predicate(job2, :valid?)
 
       refute_predicate(job3, :valid?)
-      assert_equal(['must be an instance of: String, Symbol'], job3.errors[:status])
+      assert_equal(['must be an instance of String, Symbol'], job3.errors[:status])
     end
 
     def test_the_allow_nil_validation_options
@@ -71,7 +71,7 @@ if ENV['ACTIVEMODEL_VERSION']
       assert_predicate(job1, :valid?)
 
       refute_predicate(job2, :valid?)
-      assert_equal(['must be an instance of: Float'], job2.errors[:id])
+      assert_equal(['must be an instance of Float'], job2.errors[:id])
     end
 
     # ---
@@ -92,7 +92,7 @@ if ENV['ACTIVEMODEL_VERSION']
       assert_predicate(Task.new(title: nil), :valid?)
       assert_predicate(Task.new(title: 'Buy milk'), :valid?)
 
-      assert_raises_kind_error('title must be an instance of: String') do
+      assert_raises_kind_error('title must be an instance of String') do
         Task.new(title: 42).valid?
       end
     end

--- a/test/kind/validator/kind_of_test.rb
+++ b/test/kind/validator/kind_of_test.rb
@@ -20,9 +20,9 @@ if ENV['ACTIVEMODEL_VERSION']
       invalid_person = Person.new(name: 21, age: 'John', alive: 0)
 
       refute_predicate(invalid_person, :valid?)
-      assert_equal(['must be a kind of: String'], invalid_person.errors[:name])
-      assert_equal(['must be a kind of: Integer'], invalid_person.errors[:age])
-      assert_equal(['must be a kind of: Boolean'], invalid_person.errors[:alive])
+      assert_equal(['must be a kind of String'], invalid_person.errors[:name])
+      assert_equal(['must be a kind of Integer'], invalid_person.errors[:age])
+      assert_equal(['must be a kind of Boolean'], invalid_person.errors[:alive])
 
       person = Person.new(name: 'John', age: 21, alive: false)
 
@@ -61,7 +61,7 @@ if ENV['ACTIVEMODEL_VERSION']
       assert_predicate(job2, :valid?)
 
       refute_predicate(job3, :valid?)
-      assert_equal(['must be a kind of: String, Symbol'], job3.errors[:status])
+      assert_equal(['must be a kind of String, Symbol'], job3.errors[:status])
     end
 
     def test_the_allow_nil_validation_options
@@ -71,7 +71,7 @@ if ENV['ACTIVEMODEL_VERSION']
       assert_predicate(job1, :valid?)
 
       refute_predicate(job2, :valid?)
-      assert_equal(['must be a kind of: Integer'], job2.errors[:id])
+      assert_equal(['must be a kind of Integer'], job2.errors[:id])
     end
 
     # ---
@@ -92,9 +92,40 @@ if ENV['ACTIVEMODEL_VERSION']
       assert_predicate(Task.new(title: nil), :valid?)
       assert_predicate(Task.new(title: 'Buy milk'), :valid?)
 
-      assert_raises_kind_error('title must be a kind of: String') do
+      assert_raises_kind_error('title must be a kind of String') do
         Task.new(title: 42).valid?
       end
+    end
+
+    class User
+      include ActiveModel::Validations
+
+      attr_reader :name, :bool
+
+      FilledString = ->(value) { value.kind_of?(String) && !value.empty? }
+
+      Bool = Object.new
+      def Bool.===(value)
+        value == true || value == false
+      end
+      def Bool.name; 'Bool'; end
+
+      validates :name, kind: FilledString
+      validates :bool, kind: Bool
+
+      def initialize(name:, bool:)
+      @name, @bool = name, bool
+      end
+    end
+
+    def test_the_usage_of_lambdas_to_perform_validations
+      invalid_user = User.new(name: '', bool: 1)
+
+      refute_predicate(invalid_user, :valid?)
+      assert_equal(['invalid kind'], invalid_user.errors[:name])
+      assert_equal(['must be a kind of Bool'], invalid_user.errors[:bool])
+
+      assert User.new(name: 'Serradura', bool: true).valid?
     end
   end
 end


### PR DESCRIPTION
Bump release to 5.2.0

### Add

- Improve `Kind::Validator`, now will be possible to make use of `lambdas` or objects that responds to `.===` and `.name` to perform a kind validation. e.g.
  ```ruby
  class User
    include ActiveModel::Validations

    attr_reader :name, :bool

    FilledString = ->(value) { value.kind_of?(String) && !value.empty? }

    Bool = Object.new
    def Bool.===(value)
      value == true || value == false
    end
    def Bool.name; 'Bool'; end

    validates :name, kind: FilledString
    validates :bool, kind: Bool

    def initialize(name:, bool:)
      @name, @bool = name, bool
    end
  end

  user = User.new(name: '', bool: 1)

  user.valid?        # true
  user.errors[:name] # ['invalid kind']
  user.errors[:bool] # ['must be a kind of Bool']

  User.new(name: 'Serradura', bool: true).valid? # true
  ```

- Add `Kind::Enum.===`.