### PR TITLE
Add step adapters for Kind::Action and Kind::Functional::Action

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -21,6 +21,8 @@ function run_basic_tests {
   eval "KIND_BASIC=t $bundle_cmd exec rake test TEST='test/kind/{functional/*_test,functional_test}.rb'"
   eval "KIND_BASIC=t $bundle_cmd exec rake test TEST='test/kind/either/*_test.rb'"
   eval "KIND_BASIC=t $bundle_cmd exec rake test TEST='test/kind/result/*_test.rb'"
+
+  eval "KIND_STRICT=t $bundle_cmd exec rake test TEST='test/kind/strict_disabled_test.rb'"
 }
 
 function run_with_bundler {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,73 +3,75 @@
 This project follows [semver 2.0.0](http://semver.org/spec/v2.0.0.html) and the recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 - [Unreleased](#unreleased)
-- [5.2.0 (2021-03-17)](#520-2021-03-17)
+- [5.3.0 (2021-03-23)](#530-2021-03-23)
   - [Added](#added)
+- [5.2.0 (2021-03-17)](#520-2021-03-17)
+  - [Added](#added-1)
   - [Deprecated](#deprecated)
   - [Changes](#changes)
 - [5.1.0 (2021-02-23)](#510-2021-02-23)
-  - [Added](#added-1)
+  - [Added](#added-2)
   - [Deprecated](#deprecated-1)
 - [5.0.0 (2021-02-22)](#500-2021-02-22)
   - [Breaking Changes](#breaking-changes)
   - [Removed](#removed)
 - [4.1.0 (2021-02-22)](#410-2021-02-22)
-  - [Added](#added-2)
-- [4.0.0 (2021-02-22)](#400-2021-02-22)
   - [Added](#added-3)
+- [4.0.0 (2021-02-22)](#400-2021-02-22)
+  - [Added](#added-4)
   - [Deprecated](#deprecated-2)
   - [Fixed](#fixed)
 - [3.1.0 (2020-07-08)](#310-2020-07-08)
-  - [Added](#added-4)
+  - [Added](#added-5)
 - [3.0.0 (2020-06-25)](#300-2020-06-25)
   - [Breaking Changes](#breaking-changes-1)
-  - [Added](#added-5)
-- [2.3.0 (2020-06-24)](#230-2020-06-24)
   - [Added](#added-6)
-- [2.2.0 (2020-06-23)](#220-2020-06-23)
+- [2.3.0 (2020-06-24)](#230-2020-06-24)
   - [Added](#added-7)
-- [2.1.0 (2020-05-12)](#210-2020-05-12)
+- [2.2.0 (2020-06-23)](#220-2020-06-23)
   - [Added](#added-8)
+- [2.1.0 (2020-05-12)](#210-2020-05-12)
+  - [Added](#added-9)
   - [Breaking Changes](#breaking-changes-2)
 - [2.0.0 (2020-05-07)](#200-2020-05-07)
-  - [Added](#added-9)
+  - [Added](#added-10)
   - [Breaking Changes](#breaking-changes-3)
   - [Removed](#removed-1)
 - [1.9.0 (2020-05-06)](#190-2020-05-06)
-  - [Added](#added-10)
-- [1.8.0 (2020-05-03)](#180-2020-05-03)
   - [Added](#added-11)
+- [1.8.0 (2020-05-03)](#180-2020-05-03)
+  - [Added](#added-12)
 - [1.7.0 (2020-05-03)](#170-2020-05-03)
   - [Fixed](#fixed-1)
 - [1.6.0 (2020-04-17)](#160-2020-04-17)
-  - [Added](#added-12)
+  - [Added](#added-13)
   - [Changes](#changes-1)
 - [1.5.0 (2020-04-12)](#150-2020-04-12)
-  - [Added](#added-13)
-- [1.4.0 (2020-04-12)](#140-2020-04-12)
   - [Added](#added-14)
-- [1.3.0 (2020-04-12)](#130-2020-04-12)
+- [1.4.0 (2020-04-12)](#140-2020-04-12)
   - [Added](#added-15)
-- [1.2.0 (2020-04-12)](#120-2020-04-12)
+- [1.3.0 (2020-04-12)](#130-2020-04-12)
   - [Added](#added-16)
-- [1.1.0 (2020-04-09)](#110-2020-04-09)
+- [1.2.0 (2020-04-12)](#120-2020-04-12)
   - [Added](#added-17)
+- [1.1.0 (2020-04-09)](#110-2020-04-09)
+  - [Added](#added-18)
   - [Fixed](#fixed-2)
 - [1.0.0 (2020-03-16)](#100-2020-03-16)
-  - [Added](#added-18)
-- [0.6.0 (2020-01-06)](#060-2020-01-06)
   - [Added](#added-19)
-- [0.5.0 (2020-01-04)](#050-2020-01-04)
+- [0.6.0 (2020-01-06)](#060-2020-01-06)
   - [Added](#added-20)
-- [0.4.0 (2020-01-03)](#040-2020-01-03)
+- [0.5.0 (2020-01-04)](#050-2020-01-04)
   - [Added](#added-21)
-- [0.3.0 (2020-01-03)](#030-2020-01-03)
+- [0.4.0 (2020-01-03)](#040-2020-01-03)
   - [Added](#added-22)
+- [0.3.0 (2020-01-03)](#030-2020-01-03)
+  - [Added](#added-23)
   - [Breaking Changes](#breaking-changes-4)
 - [0.2.0 (2020-01-02)](#020-2020-01-02)
-  - [Added](#added-23)
-- [0.1.0 (2019-12-26)](#010-2019-12-26)
   - [Added](#added-24)
+- [0.1.0 (2019-12-26)](#010-2019-12-26)
+  - [Added](#added-25)
 
 ## Unreleased
 
@@ -80,6 +82,45 @@ This project follows [semver 2.0.0](http://semver.org/spec/v2.0.0.html) and the 
 ### Removed
 ### Fixed
 -->
+
+5.3.0 (2021-03-23)
+------------------
+
+### Added
+
+* [#53](https://github.com/serradura/kind/pull/53) - Allow `Kind::Result#map` and `Kind::Result#map!` receive a callable as an argument.
+
+* [#53](https://github.com/serradura/kind/pull/53) - Add `|` and `>>` as an alias of `Kind::Result#map!`.
+
+* [#53](https://github.com/serradura/kind/pull/53) - Add step adapters for `Kind::Action` and `Kind::Functional::Action`. This is the list of methods: `Step`, `Map`, `Try`, `Tee`, `Check`.
+  ```ruby
+  module CreateUser
+    extend Kind::Functional::Action
+
+    def call!(input)
+      Step!(:validate, input) \
+        | Step(:create)
+    end
+
+    private
+
+    def validate(input)
+      # returns Success(valid_data) or Failure(validation)
+    end
+
+    def create(input)
+      # returns Success(user)
+    end
+  end
+  ```
+
+* [#53](https://github.com/serradura/kind/pull/53) - Add `kind/strict/disabled` to turn off all of the strict validations and optimize the runtime. Use case: As strict validation is useful in development, this mechanism could be used to optimize the runtime in production. List of methods that will be disabled:
+  * `Kind.of()`
+  * `Kind.of_class()`
+  * `Kind.of_module()`
+  * `Kind.of_module_or_class()`
+  * `Kind::<Type>[1]`
+  * `Kind::NotNil[1]`
 
 5.2.0 (2021-03-17)
 ------------------

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ One of the goals of this project is to do simple type checking like `"some strin
 Version    | Documentation
 ---------- | -------------
 unreleased | https://github.com/serradura/kind/blob/main/README.md
-5.2.0      | https://github.com/serradura/kind/blob/v5.x/README.md
+5.3.0      | https://github.com/serradura/kind/blob/v5.x/README.md
 4.1.0      | https://github.com/serradura/kind/blob/v4.x/README.md
 3.1.0      | https://github.com/serradura/kind/blob/v3.x/README.md
 2.3.0      | https://github.com/serradura/kind/blob/v2.x/README.md
@@ -123,7 +123,7 @@ unreleased | https://github.com/serradura/kind/blob/main/README.md
 | kind           | branch  | ruby     |  activemodel   |
 | -------------- | ------- | -------- | -------------- |
 | unreleased     | main    | >= 2.1.0 | >= 3.2, <= 6.1 |
-| 5.2.0          | v5.x    | >= 2.1.0 | >= 3.2, <= 6.1 |
+| 5.3.0          | v5.x    | >= 2.1.0 | >= 3.2, <= 6.1 |
 | 4.1.0          | v4.x    | >= 2.2.0 | >= 3.2, <= 6.1 |
 | 3.1.0          | v3.x    | >= 2.2.0 | >= 3.2, <= 6.1 |
 | 2.3.0          | v2.x    | >= 2.2.0 | >= 3.2, <= 6.0 |

--- a/lib/kind/__lib__/action_steps.rb
+++ b/lib/kind/__lib__/action_steps.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Kind
+  module ACTION_STEPS
+    private
+
+      def Check(mthod); ->(value) { __Check(thod, value) }; end
+      def Step(mthod); ->(value) { __Step(mthod, value) }; end
+      def Map(mthod); ->(value) { __Map(mthod, value) }; end
+      def Tee(mthod); ->(value) { __Tee(mthod, value) }; end
+      def Try(mthod, opt = Empty::HASH)
+        ->(value) { __Try(mthod, value, opt) }
+      end
+
+      def Check!(mthod, value); __Check(mthod, value); end
+      def Step!(mthod, value); __Step(mthod, value); end
+      def Map!(mthod, value); __Map(mthod, value); end
+      def Tee!(mthod, value); __Tee(mthod, value); end
+      def Try!(mthod, value, opt = Empty::HASH); __Try(mthod, value, opt); end
+
+      def __Check(mthod, value) # :nodoc:
+        __resolve_step(mthod, value) ? Success(mthod, value) : Failure(mthod, value)
+      end
+
+      def __Step(mthod, value) # :nodoc:
+        __resolve_step(mthod, value)
+      end
+
+      def __Map(mthod, value) # :nodoc:
+        Success(mthod, __resolve_step(mthod, value))
+      end
+
+      def __Tee(mthod, value) # :nodoc:
+        __resolve_step(mthod, value)
+
+        Success(mthod, value)
+      end
+
+      def __Try(mthod, value, opt = Empty::HASH) # :nodoc:
+        begin
+          Success(mthod, __resolve_step(mthod, value))
+        rescue opt.fetch(:catch, StandardError) => e
+          Failure(mthod, __map_step_exception(e))
+        end
+      end
+
+      def __resolve_step(mthod, value) # :nodoc:
+        send(mthod, value)
+      end
+
+      def __map_step_exception(value) # :nodoc:
+        value
+      end
+  end
+
+  private_constant :ACTION_STEPS
+end

--- a/lib/kind/__lib__/attributes.rb
+++ b/lib/kind/__lib__/attributes.rb
@@ -8,7 +8,7 @@ module Kind
     extend self
 
     def name!(name)
-      KIND.of!(::Symbol, name)
+      STRICT.kind_of(::Symbol, name)
     end
 
     def value(kind, default, visibility = :private)

--- a/lib/kind/__lib__/kind.rb
+++ b/lib/kind/__lib__/kind.rb
@@ -4,7 +4,7 @@ module Kind
   module KIND
     extend self
 
-    def null?(value) # :nodoc:
+    def nil_or_undefined?(value) # :nodoc:
       value.nil? || Undefined == value
     end
 
@@ -26,10 +26,6 @@ module Kind
 
     def of_class?(value) # :nodoc:
       value.kind_of?(::Class)
-    end
-
-    def of_module?(value) # :nodoc:
-      ::Module == value || (value.kind_of?(::Module) && !of_class?(value))
     end
 
     def of_module_or_class!(value) # :nodoc:

--- a/lib/kind/__lib__/kind.rb
+++ b/lib/kind/__lib__/kind.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'kind/__lib__/strict'
+
 module Kind
   module KIND
     extend self
@@ -12,24 +14,6 @@ module Kind
       of_kind = -> value { kind === value }
 
       values.empty? ? of_kind : values.all?(&of_kind)
-    end
-
-    def of!(kind, value, kind_name = nil) # :nodoc:
-      return value if kind === value
-
-      error!(kind_name || kind.name, value)
-    end
-
-    def error!(kind_name, value, label = nil) # :nodoc:
-      raise Error.new(kind_name, value, label: label)
-    end
-
-    def of_class?(value) # :nodoc:
-      value.kind_of?(::Class)
-    end
-
-    def of_module_or_class!(value) # :nodoc:
-      of!(::Module, value, 'Module/Class')
     end
 
     def respond_to!(method_name, value) # :nodoc:
@@ -47,15 +31,15 @@ module Kind
     end
 
     def is?(expected, value) # :nodoc:
-      is(of_module_or_class!(expected), value)
+      is(STRICT.module_or_class(expected), value)
     end
 
     private
 
       def is(expected_kind, value) # :nodoc:
-        kind = of_module_or_class!(value)
+        kind = STRICT.module_or_class(value)
 
-        if of_class?(kind)
+        if OF.class?(kind)
           kind <= expected_kind || expected_kind == ::Class
         else
           kind == expected_kind || kind.kind_of?(expected_kind)

--- a/lib/kind/__lib__/of.rb
+++ b/lib/kind/__lib__/of.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Kind
+  module OF
+    extend self
+
+    def class?(value) # :nodoc:
+      value.kind_of?(::Class)
+    end
+
+    def module?(value) # :nodoc:
+      ::Module == value || (value.kind_of?(::Module) && !class?(value))
+    end
+  end
+
+  private_constant :OF
+end

--- a/lib/kind/__lib__/strict.rb
+++ b/lib/kind/__lib__/strict.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'kind/__lib__/of'
+
+module Kind
+  module STRICT
+    extend self
+
+    def error(kind_name, value, label = nil) # :nodoc:
+      raise Error.new(kind_name, value, label: label)
+    end
+
+    def object_is_a(kind, value, label = nil) # :nodoc:
+      return value if kind === value
+
+      error(kind.name, value, label)
+    end
+
+    def kind_of(kind, value, kind_name = nil) # :nodoc:
+      return value if kind === value
+
+      error(kind_name || kind.name, value)
+    end
+
+    def module_or_class(value) # :nodoc:
+      kind_of(::Module, value, 'Module/Class')
+    end
+
+    def class!(value) # :nodoc:
+      kind_of(::Class, value)
+    end
+
+    def module!(value) # :nodoc:
+      return value if OF.module?(value)
+
+      error('Module', value)
+    end
+
+    def not_nil(value, label) # :nodoc:
+      return value unless value.nil?
+
+      label_text = label ? "#{label}: " : ''
+
+      raise Error.new("#{label_text}expected to not be nil")
+    end
+  end
+
+  private_constant :STRICT
+end

--- a/lib/kind/basic.rb
+++ b/lib/kind/basic.rb
@@ -35,11 +35,11 @@ module Kind
   end
 
   def of_class?(value)
-    KIND.of_class?(value)
+    OF.class?(value)
   end
 
   def of_module?(value)
-    ::Module == value || (value.kind_of?(::Module) && !KIND.of_class?(value))
+    OF.module?(value)
   end
 
   def respond_to?(value, *method_names)
@@ -49,25 +49,21 @@ module Kind
   end
 
   def of(kind, value, label: nil)
-    return value if kind === value
-
-    KIND.error!(kind.name, value, label)
+    STRICT.object_is_a(kind, value, label)
   end
 
   alias_method :of!, :of
 
   def of_class(value)
-    KIND.of!(::Class, value)
+    STRICT.class!(value)
   end
 
   def of_module(value)
-    return value if of_module?(value)
-
-    KIND.error!('Module', value)
+    STRICT.module!(value)
   end
 
   def of_module_or_class(value)
-    KIND.of_module_or_class!(value)
+    STRICT.module_or_class(value)
   end
 
   def respond_to(value, *method_names)

--- a/lib/kind/basic.rb
+++ b/lib/kind/basic.rb
@@ -39,7 +39,7 @@ module Kind
   end
 
   def of_module?(value)
-    KIND.of_module?(value)
+    ::Module == value || (value.kind_of?(::Module) && !KIND.of_class?(value))
   end
 
   def respond_to?(value, *method_names)
@@ -55,6 +55,16 @@ module Kind
   end
 
   alias_method :of!, :of
+
+  def of_class(value)
+    KIND.of!(::Class, value)
+  end
+
+  def of_module(value)
+    return value if of_module?(value)
+
+    KIND.error!('Module', value)
+  end
 
   def of_module_or_class(value)
     KIND.of_module_or_class!(value)

--- a/lib/kind/dig.rb
+++ b/lib/kind/dig.rb
@@ -12,7 +12,7 @@ module Kind
       keys.reduce(data) do |memo, key|
         value = get(memo, key)
 
-        break if KIND.null?(value)
+        break if KIND.nil_or_undefined?(value)
 
         value
       end
@@ -25,7 +25,7 @@ module Kind
 
       return result unless block_given?
 
-      yield(result) unless KIND.null?(result)
+      yield(result) unless KIND.nil_or_undefined?(result)
     end
 
     def presence(*args, &block)

--- a/lib/kind/function.rb
+++ b/lib/kind/function.rb
@@ -17,9 +17,7 @@ module Kind
     end
 
     def self.extended(base)
-      KIND.error!('Module', base) unless Kind.of_module?(base)
-
-      base.extend(base)
+      base.extend(Kind.of_module(base))
     end
 
     def kind_function!

--- a/lib/kind/functional.rb
+++ b/lib/kind/functional.rb
@@ -11,7 +11,7 @@ module Kind
     end
 
     def self.included(base)
-      KIND.of!(::Class, base).send(:extend, ClassMethods)
+      Kind.of_class(base).send(:extend, ClassMethods)
     end
 
     module Behavior

--- a/lib/kind/functional.rb
+++ b/lib/kind/functional.rb
@@ -22,7 +22,7 @@ module Kind
       end
 
       def initialize(arg = Empty::HASH)
-        hash = KIND.of!(::Hash, arg)
+        hash = STRICT.kind_of(::Hash, arg)
 
         self.class.__dependencies__.each do |name, (kind, default, _visibility)|
           value_to_assign = ATTRIBUTES.value_to_assign!(kind, default, hash, name)

--- a/lib/kind/functional/action.rb
+++ b/lib/kind/functional/action.rb
@@ -2,6 +2,7 @@
 
 require 'kind/result'
 require 'kind/functional'
+require 'kind/__lib__/action_steps'
 
 module Kind
   module Functional::Action
@@ -56,10 +57,12 @@ module Kind
           "#{CALL_TMPL % [call_tmpl_args, call_tmpl_args]}"
         )
 
-        if KIND.of_module?(self)
+        if Kind.of_module?(self)
           self.send(:extend, Result::Methods)
+          self.send(:extend, ACTION_STEPS)
         else
           self.send(:include, Result::Methods)
+          self.send(:include, ACTION_STEPS)
           self.send(:include, Functional::Behavior)
 
           __dependencies__.freeze
@@ -72,15 +75,13 @@ module Kind
     end
 
     def self.included(base)
-      KIND.of!(::Class, base).send(:extend, Functional::DependencyInjection)
+      Kind.of_class(base).send(:extend, Functional::DependencyInjection)
 
       base.send(:extend, Macros)
     end
 
     def self.extended(base)
-      KIND.error!('Module', base) unless Kind.of_module?(base)
-
-      base.send(:extend, base)
+      base.send(:extend, Kind.of_module(base))
       base.send(:extend, Macros)
     end
 

--- a/lib/kind/immutable_attributes/reader.rb
+++ b/lib/kind/immutable_attributes/reader.rb
@@ -28,7 +28,7 @@ module Kind
       end
 
       def with_attributes(arg)
-        hash = KIND.of!(::Hash, arg)
+        hash = STRICT.kind_of(::Hash, arg)
 
         self.class.new(@_____attrs.merge(hash))
       end

--- a/lib/kind/maybe.rb
+++ b/lib/kind/maybe.rb
@@ -14,7 +14,7 @@ module Kind
     extend self
 
     def new(value)
-      (::Exception === value || KIND.null?(value) ? None : Some)
+      (::Exception === value || KIND.nil_or_undefined?(value) ? None : Some)
         .new(value)
     end
 

--- a/lib/kind/maybe/none.rb
+++ b/lib/kind/maybe/none.rb
@@ -25,7 +25,7 @@ module Kind
       alias_method :and_then!, :map!
 
       def try!(method_name = UNDEFINED, *args, &block)
-        KIND.of!(::Symbol, method_name)if UNDEFINED != method_name
+        STRICT.kind_of(::Symbol, method_name)if UNDEFINED != method_name
 
         self
       end

--- a/lib/kind/maybe/some.rb
+++ b/lib/kind/maybe/some.rb
@@ -6,7 +6,7 @@ require 'kind/presence'
 module Kind
   module Maybe
     class Some < Monad
-      KindSymbol = ->(value) { KIND.of!(::Symbol, value) }
+      KindSymbol = ->(value) { STRICT.kind_of(::Symbol, value) }
 
       VALUE_CANT_BE_NONE = "value can't be nil or Kind::Undefined".freeze
 

--- a/lib/kind/maybe/some.rb
+++ b/lib/kind/maybe/some.rb
@@ -11,7 +11,7 @@ module Kind
       VALUE_CANT_BE_NONE = "value can't be nil or Kind::Undefined".freeze
 
       def self.[](value)
-        return new(value) if !KIND.null?(value)
+        return new(value) if !KIND.nil_or_undefined?(value)
 
         raise ArgumentError, VALUE_CANT_BE_NONE
       end
@@ -57,7 +57,7 @@ module Kind
           fn.call(@value)
         end
 
-        !result || KIND.null?(result) ? NONE_INSTANCE : self
+        !result || KIND.nil_or_undefined?(result) ? NONE_INSTANCE : self
       end
 
       alias_method :accept, :check
@@ -73,7 +73,7 @@ module Kind
           fn.call(@value)
         end
 
-        result || KIND.null?(result) ? NONE_INSTANCE : self
+        result || KIND.nil_or_undefined?(result) ? NONE_INSTANCE : self
       end
 
       def try!(method_name = UNDEFINED, *args, &block)
@@ -120,7 +120,7 @@ module Kind
 
         def resolve(result)
           return result if Maybe::None === result
-          return NONE_INSTANCE if KIND.null?(result)
+          return NONE_INSTANCE if KIND.nil_or_undefined?(result)
           return None.new(result) if ::Exception === result
 
           Some.new(result)

--- a/lib/kind/objects/basic_object.rb
+++ b/lib/kind/objects/basic_object.rb
@@ -3,9 +3,7 @@
 module Kind
   module BasicObject
     def [](value, label: nil)
-      return value if self === value
-
-      KIND.error!(name, value, label)
+      STRICT.object_is_a(self, value, label)
     end
 
     def or_nil(value)

--- a/lib/kind/objects/basic_object.rb
+++ b/lib/kind/objects/basic_object.rb
@@ -33,7 +33,7 @@ module Kind
     end
 
     def or_null(value) # :nodoc:
-      KIND.null?(value) ? value : self[value]
+      KIND.nil_or_undefined?(value) ? value : self[value]
     end
 
     private

--- a/lib/kind/objects/not_nil.rb
+++ b/lib/kind/objects/not_nil.rb
@@ -3,11 +3,7 @@
 module Kind
   module NotNil
     def self.[](value, label: nil)
-      return value unless value.nil?
-
-      label_text = label ? "#{label}: " : ''
-
-      raise Error.new("#{label_text}expected to not be nil")
+      STRICT.not_nil(value, label)
     end
   end
 end

--- a/lib/kind/objects/object.rb
+++ b/lib/kind/objects/object.rb
@@ -34,7 +34,7 @@ module Kind
     def initialize(kind, opt)
       name = ResolveKindName.(kind, opt)
 
-      @name = KIND.of!(::String, name)
+      @name = STRICT.kind_of(::String, name)
       @kind = KIND.respond_to!(:===, kind)
     end
 

--- a/lib/kind/objects/respond_to.rb
+++ b/lib/kind/objects/respond_to.rb
@@ -5,7 +5,7 @@ module Kind
     include Kind::BasicObject
 
     def self.[](*args)
-      args.each { |arg| KIND.of!(::Symbol, arg) }
+      args.each { |arg| STRICT.kind_of(::Symbol, arg) }
 
       new(args)
     end

--- a/lib/kind/presence.rb
+++ b/lib/kind/presence.rb
@@ -7,7 +7,7 @@ module Kind
     extend self
 
     def call(object)
-      return if KIND.null?(object)
+      return if KIND.nil_or_undefined?(object)
 
       return object.blank? ? nil : object if object.respond_to?(:blank?)
 

--- a/lib/kind/result/failure.rb
+++ b/lib/kind/result/failure.rb
@@ -14,10 +14,12 @@ module Kind
       UNDEFINED != default ? default : block.call
     end
 
-    def map(&_)
+    def map(_ = UNDEFINED, &_fn)
       self
     end
 
+    alias_method :|, :map
+    alias_method :>>, :map
     alias_method :map!, :map
     alias_method :then, :map
     alias_method :then!, :map

--- a/lib/kind/result/monad.rb
+++ b/lib/kind/result/monad.rb
@@ -12,13 +12,13 @@ module Kind
     def self.[](arg1 = UNDEFINED, arg2 = UNDEFINED, opt = Empty::HASH) # :nodoc:
       value_must_be_a = opt[:value_must_be_a]
 
-      type = UNDEFINED == arg2 ? self::DEFAULT_TYPE : KIND.of!(::Symbol, arg1)
+      type = UNDEFINED == arg2 ? self::DEFAULT_TYPE : STRICT.kind_of(::Symbol, arg1)
 
       Error.wrong_number_of_args!(given: 0, expected: '1 or 2') if UNDEFINED == arg1
 
       value = UNDEFINED == arg2 ? arg1 : arg2
 
-      new(type, (value_must_be_a ? KIND.of!(value_must_be_a, value) : value))
+      new(type, (value_must_be_a ? STRICT.kind_of(value_must_be_a, value) : value))
     end
 
     private_class_method :new

--- a/lib/kind/result/monad.rb
+++ b/lib/kind/result/monad.rb
@@ -4,11 +4,14 @@ module Kind
   class Result::Monad
     include Result::Abstract
 
+    require 'kind/empty'
     require 'kind/result/monad/wrapper'
 
     attr_reader :type, :value
 
-    def self.[](arg1 = UNDEFINED, arg2 = UNDEFINED, value_must_be_a: nil) # :nodoc:
+    def self.[](arg1 = UNDEFINED, arg2 = UNDEFINED, opt = Empty::HASH) # :nodoc:
+      value_must_be_a = opt[:value_must_be_a]
+
       type = UNDEFINED == arg2 ? self::DEFAULT_TYPE : KIND.of!(::Symbol, arg1)
 
       Error.wrong_number_of_args!(given: 0, expected: '1 or 2') if UNDEFINED == arg1
@@ -29,10 +32,12 @@ module Kind
       raise NotImplementedError
     end
 
-    def map(&_)
+    def map(_ = UNDEFINED, &_fn)
       raise NotImplementedError
     end
 
+    alias_method :|, :map
+    alias_method :>>, :map
     alias_method :map!, :map
     alias_method :then, :map
     alias_method :then!, :map

--- a/lib/kind/result/success.rb
+++ b/lib/kind/result/success.rb
@@ -12,29 +12,42 @@ module Kind
       @value
     end
 
-    def map(&fn)
-      map!(&fn)
+    def map(callable = UNDEFINED, &fn)
+      _resolve_map(callable, fn)
     rescue Kind::Monad::Error => e
       raise e
     rescue StandardError => e
       Result::Failure[:exception, e]
     end
 
-    def map!(&fn)
-      monad = fn.call(@value)
+    alias_method :then, :map
+    alias_method :and_then, :map
 
-      return monad if Result::Monad === monad
-
-      raise Kind::Monad::Error.new('Kind::Success | Kind::Failure', monad)
+    def map!(callable = UNDEFINED, &fn)
+      _resolve_map(callable, fn)
     end
 
-    alias_method :then, :map
+    alias_method :|, :map!
+    alias_method :>>, :map!
     alias_method :then!, :map!
-    alias_method :and_then, :map
     alias_method :and_then!, :map!
 
     def inspect
       '#<%s type=%p value=%p>' % ['Kind::Success', type, value]
     end
+
+    private
+
+      def _resolve_map(callable, fn)
+        callable.respond_to?(:call) ? _map(callable) : _map(fn)
+      end
+
+      def _map(fn)
+        monad = fn.call(@value)
+
+        return monad if Result::Monad === monad
+
+        raise Kind::Monad::Error.new('Kind::Success | Kind::Failure', monad)
+      end
   end
 end

--- a/lib/kind/strict/disabled.rb
+++ b/lib/kind/strict/disabled.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Kind
+  module STRICT
+    [
+      :object_is_a, :class!, :kind_of,
+      :module_or_class, :module!, :not_nil
+    ].each { |method_name| remove_method(method_name) }
+
+    def object_is_a(_kind, value, _label = nil) # :nodoc:
+      value
+    end
+
+    def class!(value) # :nodoc:
+      value
+    end
+
+    def kind_of(_kind, value, _kind_name = nil) # :nodoc:
+      value
+    end
+
+    def module_or_class(value) # :nodoc:
+      value
+    end
+
+    def module!(value) # :nodoc:
+      value
+    end
+
+    def not_nil(value, label) # :nodoc:
+      value
+    end
+  end
+end

--- a/lib/kind/try.rb
+++ b/lib/kind/try.rb
@@ -9,7 +9,7 @@ module Kind
     extend self
 
     def call!(object, method_name, args = Empty::ARRAY) # :nodoc
-      return if KIND.null?(object)
+      return if KIND.nil_or_undefined?(object)
 
       resolve(object, method_name, args)
     end
@@ -21,7 +21,7 @@ module Kind
 
       return result unless block_given?
 
-      yield(result) unless KIND.null?(result)
+      yield(result) unless KIND.nil_or_undefined?(result)
     end
 
     def presence(*args, &block)

--- a/lib/kind/validator.rb
+++ b/lib/kind/validator.rb
@@ -101,7 +101,7 @@ class KindValidator < ActiveModel::EachValidator
     def kind_is_not(expected, value)
       case expected
       when ::Class
-        return if expected == Kind.of!(::Class, value) || value < expected
+        return if expected == Kind.of_class(value) || value < expected
 
         "must be the class or a subclass of `#{expected.name}`"
       when ::Module

--- a/lib/kind/version.rb
+++ b/lib/kind/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Kind
-  VERSION = '5.2.0'
+  VERSION = '5.3.0'
 end

--- a/test/kind/action/step_adapters_test.rb
+++ b/test/kind/action/step_adapters_test.rb
@@ -1,0 +1,253 @@
+require 'test_helper'
+
+class KindActionStepAdaptersTest < Minitest::Test
+  require 'kind/action'
+
+  DB = []
+
+  class CreateUser
+    include Kind::Action
+
+    attribute :name
+    attribute :email
+
+    def call!
+      Step!(:validate) \
+        >> Step(:create) \
+        >> Step(:welcome_email)
+    end
+
+    private
+
+      def validate
+        return Success() if name && email
+
+        Failure(message: 'ops... Name and email must be present!')
+      end
+
+      def create
+        return Success() if DB.push(attributes)
+
+        Failure(message: 'Panic!!!')
+      end
+
+      def welcome_email
+        # UserMailer.welcome(email).deliver_later
+
+        Success(message: 'Please, confirm your email.')
+      end
+
+    kind_action!
+  end
+
+  def test_the_create_user
+    DB.clear
+
+    # --
+
+    result1 = CreateUser.(name: nil, email: nil)
+
+    assert result1.failure?
+    assert_equal(:error, result1.type)
+    assert_equal({message: 'ops... Name and email must be present!'}, result1.value)
+
+    # --
+
+    result2 = CreateUser.(name: 'Rodrigo', email: 'rodrigo.serradura@gmail.com')
+
+    assert result2.success?
+    assert_equal(:ok, result2.type)
+    assert_equal({message: 'Please, confirm your email.'}, result2.value)
+
+    assert_equal(
+      {name: 'Rodrigo', email: 'rodrigo.serradura@gmail.com'},
+      DB.last
+    )
+  end
+
+  class Add
+    include Kind::Action
+
+    attribute :a
+    attribute :b
+
+    def call!
+      Check!(:presence) \
+        | Map(:normalize) \
+        | Map(:calc)
+    end
+
+    private
+
+      def presence
+        a && b
+      end
+
+      def normalize
+        { a: a.to_i, b: b.to_i }
+      end
+
+      def calc(numbers)
+        { number: numbers[:a] + numbers[:b] }
+      end
+
+    kind_action!
+  end
+
+  def test_the_addition
+    result1 = Add.({})
+
+    assert result1.failure?
+    assert_equal(:presence, result1.type)
+
+    assert_equal({}, result1.value)
+
+    # --
+
+    result2 = Add.(a: '1', b: 2)
+
+    assert result2.success?
+    assert_equal(:calc, result2.type)
+    assert_equal({number: 3}, result2.value)
+  end
+
+  class Divide
+    include Kind::Action
+
+    attribute :a
+    attribute :b
+
+    def call!
+      Try!(:calc, catch: ZeroDivisionError)
+    end
+
+    private
+
+      def calc
+        { number: a / b }
+      end
+
+    kind_action!
+  end
+
+  class DivideByZero
+    include Kind::Action
+
+    attribute :a
+
+    def call!
+      Map!(:normalize) \
+        | Try(:calc, catch: ZeroDivisionError)
+    end
+
+    private
+
+      def normalize
+        { a: a.to_i }
+      end
+
+      def calc(input)
+        { number: input[:a] / 0 }
+      end
+
+    kind_action!
+  end
+
+  def test_the_division
+    result1 = Divide.(a: 4, b: 2)
+
+    assert result1.success?
+    assert_equal(:calc, result1.type)
+    assert_equal({number: 2}, result1.value)
+
+    # --
+
+    result2 = Divide.(a: 2, b: 0)
+
+    assert result2.failure?
+    assert_equal(:calc, result2.type)
+    assert_instance_of(ZeroDivisionError, result2.value[:exception])
+
+    # --
+
+    assert_raises(TypeError) { Divide.(a: 4, b: '2') }
+
+    # --
+
+    result3 = DivideByZero.(a: '2')
+
+    assert result3.failure?
+    assert_equal(:calc, result3.type)
+    assert_instance_of(ZeroDivisionError, result3.value[:exception])
+  end
+
+  LOG = []
+
+  class Multiply
+    include Kind::Action
+
+    attribute :a
+    attribute :b
+
+    def call!
+      Check!(:presence) \
+        | Step(:do_something) \
+        | Tee(:log) \
+        | Map(:calc)
+    end
+
+    private
+
+      def presence
+        a && b
+      end
+
+      def do_something
+        Success(inspect: [a, b].inspect)
+      end
+
+      def log(first_output)
+        LOG << first_output[:inspect]
+      end
+
+      def calc(first_output)
+        { number: a * b }.merge(first_output)
+      end
+
+    kind_action!
+  end
+
+  def test_the_multiplication
+    LOG.clear
+
+    # --
+
+    result = Multiply.(a: 2, b: 2)
+
+    assert result.success?
+    assert_equal(:calc, result.type)
+    assert_equal({number: 4, inspect: '[2, 2]'}, result.value)
+
+    assert_equal('[2, 2]', LOG.last)
+  end
+
+  class Double
+    include Kind::Action
+
+    attribute :number
+
+    def call!
+      Success(number: number * 2)
+    end
+
+    kind_action!
+  end
+
+  def test_add_and_double
+    result = Add.(a: 1, b: 2).then(Double)
+
+    assert result.success?
+    assert_equal(:ok, result.type)
+    assert_equal({number: 6}, result.value)
+  end
+end

--- a/test/kind/action_test.rb
+++ b/test/kind/action_test.rb
@@ -170,4 +170,41 @@ class KindActionTest < Minitest::Test
     assert_equal("KindActionTest::UpdateUser is a Kind::Action and it can't be inherited", @@wrong_usage_error1.message)
   end
 
+  class Sum
+    include Kind::Action
+
+    attribute :a
+    attribute :b
+
+    def call!
+      Success number: (a || 0) + (b || 0)
+    end
+
+    kind_action!
+  end
+
+  def test_inspect
+    s = Sum.allocate
+    s.send(:initialize, {})
+
+    assert_equal('#<KindActionTest::Sum attributes={:a=>nil, :b=>nil} nil_attributes=[:a, :b]>', s.inspect)
+  end
+
+  class Foo
+    include Kind::Action
+
+    def call!
+      Failure()
+    end
+
+    kind_action!
+  end
+
+  def test_failure_receiving_no_args
+    r = Foo.({})
+    assert r.failure?
+    assert_equal(:error, r.type)
+    assert_equal({}, r.value)
+  end
+
 end

--- a/test/kind/functional/action/step_adapters/classes_test.rb
+++ b/test/kind/functional/action/step_adapters/classes_test.rb
@@ -1,0 +1,146 @@
+require 'test_helper'
+
+class KindFunctionalActionStepAdaptersClassesTest < Minitest::Test
+  include StepAdapterAssertions
+
+  require 'kind/functional/action'
+
+  DB = []
+
+  class CreateUser
+    include Kind::Functional::Action
+
+    def call!(input)
+      validate(input) \
+        >> Step(:create) \
+        >> Step(:welcome_email)
+    end
+
+    private
+
+      def validate(input)
+        return Success(input) if input[:name] && input[:email]
+
+        Failure('ops... Name and email must be present!')
+      end
+
+      def create(input)
+        return Success(input[:email]) if DB.push(input)
+
+        Failure('Panic!!!')
+      end
+
+      def welcome_email(email)
+        # UserMailer.welcome(email).deliver_later
+
+        Success('Please, confirm your email.')
+      end
+
+    kind_functional_action!
+  end
+
+  def test_the_create_user
+    assert_create_user(CreateUser.new, DB)
+  end
+
+  class Add
+    include Kind::Functional::Action
+
+    def call!(input)
+      Check!(:presence, input) \
+        | Map(:normalize) \
+        | Map(:calc)
+    end
+
+    private
+
+      def presence(input)
+        input.is_a?(Hash) && input[:a] && input[:b]
+      end
+
+      def normalize(input)
+        [input[:a].to_i, input[:b].to_i]
+      end
+
+      def calc((a, b))
+        a + b
+      end
+
+    kind_functional_action!
+  end
+
+  def test_the_addition
+    assert_addition(Add.new)
+  end
+
+  class Divide
+    include Kind::Functional::Action
+
+    def call!(input)
+      normalize(input) \
+        | Try(:calc, catch: ZeroDivisionError)
+    end
+
+    private
+
+      def normalize(input)
+        Success([input[:a], input[:b]])
+      end
+
+      def calc((a, b))
+        a / b
+      end
+
+    kind_functional_action!
+  end
+
+  def test_the_division
+    assert_division(Divide.new)
+  end
+
+  LOG = []
+
+  class Multiply
+    include Kind::Functional::Action
+
+    def call!(input)
+      normalize(input) \
+        | Tee(:log)  \
+        | Map(:calc)
+    end
+
+    private
+
+      def normalize(input)
+        Success([input[:a], input[:b]])
+      end
+
+      def log(input)
+        LOG << input.inspect
+      end
+
+      def calc((a, b))
+        a * b
+      end
+
+    kind_functional_action!
+  end
+
+  def test_the_multiplication
+    assert_multiplication(Multiply.new, LOG)
+  end
+
+  class Double
+    include Kind::Functional::Action
+
+    def call!(number)
+      Success(number * 2)
+    end
+
+    kind_functional_action!
+  end
+
+  def test_add_and_double
+    assert_add_and_double(Add.new, Double.new)
+  end
+end

--- a/test/kind/functional/action/step_adapters/modules_test.rb
+++ b/test/kind/functional/action/step_adapters/modules_test.rb
@@ -1,0 +1,204 @@
+require 'test_helper'
+
+class KindFunctionalActionStepAdaptersModulesTest < Minitest::Test
+  include StepAdapterAssertions
+
+  require 'kind/functional/action'
+
+  DB = []
+
+  module CreateUser
+    extend Kind::Functional::Action
+
+    def call!(input)
+      Step!(:validate, input) \
+        >> Step(:create) \
+        >> Step(:welcome_email)
+    end
+
+    private
+
+      def validate(input)
+        return Success(input) if input[:name] && input[:email]
+
+        Failure('ops... Name and email must be present!')
+      end
+
+      def create(input)
+        return Success(input[:email]) if DB.push(input)
+
+        Failure('Panic!!!')
+      end
+
+      def welcome_email(email)
+        # UserMailer.welcome(email).deliver_later
+
+        Success('Please, confirm your email.')
+      end
+
+    kind_functional_action!
+  end
+
+  def test_the_create_user
+    assert_create_user(CreateUser, DB)
+  end
+
+  module Add
+    extend Kind::Functional::Action
+
+    def call!(input)
+      Check!(:presence, input) \
+        | Map(:normalize) \
+        | Map(:calc)
+    end
+
+    private
+
+      def presence(input)
+        input.is_a?(Hash) && input[:a] && input[:b]
+      end
+
+      def normalize(input)
+        [input[:a].to_i, input[:b].to_i]
+      end
+
+      def calc((a, b))
+        a + b
+      end
+
+    kind_functional_action!
+  end
+
+  def test_the_addition
+    assert_addition(Add)
+  end
+
+  module Divide
+    extend Kind::Functional::Action
+
+    def call!(input)
+      Map!(:normalize, input) \
+        | Try(:calc, catch: ZeroDivisionError)
+    end
+
+    private
+
+      def normalize(input)
+        [input[:a], input[:b]]
+      end
+
+      def calc((a, b))
+        a / b
+      end
+
+    kind_functional_action!
+  end
+
+  module Divide2
+    extend Kind::Functional::Action
+
+    def call!(input)
+      Try!(:calc, input, catch: ZeroDivisionError)
+    end
+
+    private
+
+      def calc(input)
+        input[:a] / input[:b]
+      end
+
+    kind_functional_action!
+  end
+
+  def test_the_division
+    assert_division(Divide)
+
+    # --
+
+    result1 = Divide2.(a: 2, b: 2)
+    assert result1.success?
+    assert_equal(1, result1.value)
+
+    # --
+
+    result2 = Divide2.(a: 2, b: 0)
+    assert result2.failure?
+    assert_instance_of(ZeroDivisionError, result2.value)
+  end
+
+  LOG = []
+
+  module Multiply
+    extend Kind::Functional::Action
+
+    def call!(input)
+      normalize(input) \
+        | Tee(:log)  \
+        | Map(:calc)
+    end
+
+    private
+
+      def normalize(input)
+        Success([input[:a], input[:b]])
+      end
+
+      def log(input)
+        LOG << input.inspect
+      end
+
+      def calc((a, b))
+        a * b
+      end
+
+    kind_functional_action!
+  end
+
+  module Multiply2
+    extend Kind::Functional::Action
+
+    def call!(input)
+      Tee!(:log, input)  \
+        | Map(:calc)
+    end
+
+    private
+
+      def log(input)
+        item = [input[:a], input[:b]]
+
+        LOG << item.inspect
+      end
+
+      def calc(input)
+        input[:a] * input[:b]
+      end
+
+    kind_functional_action!
+  end
+
+  def test_the_multiplication
+    assert_multiplication(Multiply, LOG)
+
+    # --
+
+    result = Multiply2.(a: 3, b: 3)
+    assert result.success?
+    assert_equal(9, result.value)
+    assert_equal('[3, 3]', LOG.last)
+  end
+
+  module Double
+    extend Kind::Functional::Action
+
+    def call!(number)
+      Success(number * 2)
+    end
+
+    kind_functional_action!
+  end
+
+  def test_add_and_double
+    assert_add_and_double(Add, Double)
+  end
+end

--- a/test/kind/strict_disabled_test.rb
+++ b/test/kind/strict_disabled_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class Kind::StrictDisabledTest < Minitest::Test
+  unless ENV.fetch('KIND_STRICT', '').empty?
+    require 'kind'
+    require 'kind/strict/disabled'
+
+    def test_that_strict_checks_are_disabled
+      assert_equal(1, Kind.of(String, 1))
+      assert_equal(1, Kind.of_class(1))
+      assert_equal(1, Kind.of_module(1))
+      assert_equal(1, Kind.of_module_or_class(1))
+      assert_equal(1, Kind::String[1])
+
+      assert_nil(Kind::NotNil[nil])
+    end
+  end
+end

--- a/test/kind/transaction_test.rb
+++ b/test/kind/transaction_test.rb
@@ -1,0 +1,223 @@
+require 'test_helper'
+
+class Kind::TransactionTest < Minitest::Test
+  include StepAdapterAssertions
+
+  require 'kind/empty'
+  require 'kind/result'
+
+  module Kind::Transaction
+    module StepAdapters
+      private
+
+        def Step(method_name)
+          ->(value) { send(method_name, value) }
+        end
+
+        def Map(method_name)
+          ->(value) { Success(method_name, send(method_name, value)) }
+        end
+
+        def Check(method_name)
+          ->(value) do
+            send(method_name, value) ? Success(method_name, value) : Failure(method_name, value)
+          end
+        end
+
+        def Try(method_name, opt = Empty::HASH)
+          ->(value) do
+            begin
+              Success(method_name, send(method_name, value))
+            rescue opt.fetch(:catch, StandardError) => e
+              Failure(method_name, e)
+            end
+          end
+        end
+
+        def Tee(method_name)
+          ->(value) do
+            send(method_name, value)
+
+            Success(method_name, value)
+          end
+        end
+    end
+
+    def self.extended(base)
+      base.extend(Kind.of_module(base))
+      base.send(:extend, Kind::Result::Methods)
+      base.send(:extend, StepAdapters)
+    end
+
+    def self.included(base)
+      Kind.of_class(base).send(:include, Kind::Result::Methods)
+      base.send(:include, StepAdapters)
+    end
+
+    private_constant :StepAdapters
+  end
+
+  DB = []
+
+  module CreateUser1
+    extend Kind::Transaction
+
+    def call(input)
+      validate(input) \
+        | Step(:create) \
+        | Step(:welcome_email)
+    end
+
+    private
+
+      def validate(input)
+        return Success(input) if input[:name] && input[:email]
+
+        Failure('ops... Name and email must be present!')
+      end
+
+      def create(input)
+        return Success(input[:email]) if DB.push(input)
+
+        Failure('Panic!!!')
+      end
+
+      def welcome_email(email)
+        # UserMailer.welcome(email).deliver_later
+
+        Success('Please, confirm your email.')
+      end
+  end
+
+  def test_the_create_user_module
+    assert_create_user(CreateUser1, DB)
+  end
+
+  class CreateUser2
+    include Kind::Transaction
+
+    def call(input)
+      validate(input) \
+        | Step(:create) \
+        | Step(:welcome_email)
+    end
+
+    private
+
+      def validate(input)
+        return Success(input) if input[:name] && input[:email]
+
+        Failure('ops... Name and email must be present!')
+      end
+
+      def create(input)
+        return Success(input[:email]) if DB.push(input)
+
+        Failure('Panic!!!')
+      end
+
+      def welcome_email(email)
+        # UserMailer.welcome(email).deliver_later
+
+        Success('Please, confirm your email.')
+      end
+  end
+
+  def test_the_create_user_instance
+    assert_create_user(CreateUser2.new, DB)
+  end
+
+  module Add
+    extend Kind::Transaction
+
+    def call(input)
+      Success(input) \
+        | Check(:presence) \
+        | Map(:normalize) \
+        | Map(:calc)
+    end
+
+    private
+
+      def presence(input)
+        input.is_a?(Hash) && input[:a] && input[:b]
+      end
+
+      def normalize(input)
+        [input[:a].to_i, input[:b].to_i]
+      end
+
+      def calc((a, b))
+        a + b
+      end
+  end
+
+  def test_the_addition
+    assert_addition(Add)
+  end
+
+  module Divide
+    extend Kind::Transaction
+
+    def call(input)
+      normalize(input) \
+        | Try(:calc, catch: ZeroDivisionError)
+    end
+
+    private
+
+      def normalize(input)
+        Success([input[:a], input[:b]])
+      end
+
+      def calc((a, b))
+        a / b
+      end
+  end
+
+  def test_the_division
+    assert_division(Divide)
+  end
+
+  LOG = []
+
+  module Multiply
+    extend Kind::Transaction
+
+    def call(input)
+      normalize(input) \
+        | Tee(:log)  \
+        | Map(:calc)
+    end
+
+    private
+
+      def normalize(input)
+        Success([input[:a], input[:b]])
+      end
+
+      def log(input)
+        LOG << input.inspect
+      end
+
+      def calc((a, b))
+        a * b
+      end
+  end
+
+  def test_the_multiplication
+    assert_multiplication(Multiply, LOG)
+  end
+
+  module Double
+    extend Kind::Transaction
+
+    def call(number)
+      Success(number * 2)
+    end
+  end
+
+  def test_add_and_double
+    assert_add_and_double(Add, Double)
+  end
+end

--- a/test/support/step_adapter_assertions.rb
+++ b/test/support/step_adapter_assertions.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module StepAdapterAssertions
+  def assert_create_user(create_user, db)
+    db.clear
+
+    # --
+
+    result1 = create_user.(name: nil, email: nil)
+
+    assert result1.failure?
+    assert_equal(:error, result1.type)
+    assert_equal('ops... Name and email must be present!', result1.value)
+
+    # --
+
+    result2 = create_user.(name: 'Rodrigo', email: 'rodrigo.serradura@gmail.com')
+
+    assert result2.success?
+    assert_equal(:ok, result2.type)
+    assert_equal('Please, confirm your email.', result2.value)
+
+    assert_equal(
+      {name: 'Rodrigo', email: 'rodrigo.serradura@gmail.com'},
+      db.last
+    )
+  end
+
+  def assert_addition(add)
+    result1 = add.([1, 2])
+
+    assert result1.failure?
+    assert_equal(:presence, result1.type)
+    assert_equal([1, 2], result1.value)
+
+    # --
+
+    result2 = add.(a: '1', b: 2)
+
+    assert result2.success?
+    assert_equal(:calc, result2.type)
+    assert_equal(3, result2.value)
+  end
+
+  def assert_division(divide)
+    result1 = divide.(a: 4, b: 2)
+
+    assert result1.success?
+    assert_equal(:calc, result1.type)
+    assert_equal(2, result1.value)
+
+    # --
+
+    result2 = divide.(a: 2, b: 0)
+
+    assert result2.failure?
+    assert_equal(:calc, result2.type)
+    assert_instance_of(ZeroDivisionError, result2.value)
+
+    # --
+
+    assert_raises(TypeError) { divide.(a: 4, b: '2') }
+  end
+
+  def assert_multiplication(multiply, log)
+    log.clear
+
+    # --
+
+    result = multiply.(a: 2, b: 2)
+
+    assert result.success?
+    assert_equal(:calc, result.type)
+    assert_equal(4, result.value)
+
+    assert_equal('[2, 2]', log.last)
+  end
+
+  def assert_add_and_double(add, double)
+    result = add.(a: 1, b: 2).then(double)
+
+    assert result.success?
+    assert_equal(:ok, result.type)
+    assert_equal(6, result.value)
+  end
+end
+

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,6 +28,7 @@ ENV.fetch('ACTIVEMODEL_VERSION', '7.0.0').tap do |active_model_version|
 end
 
 require_relative 'support/kind_is_test'
+require_relative 'support/step_adapter_assertions'
 
 require 'minitest/pride'
 require 'minitest/autorun'


### PR DESCRIPTION
### Added

- Allow `Kind::Result#map` and `Kind::Result#map!` receive a callable as an argument.

- Add `|` and `>>` as an alias of `Kind::Result#map!`.

- Add step adapters for `Kind::Action` and `Kind::Functional::Action`. This is the list of methods: `Step`, `Map`, `Try`, `Tee`, `Check`.
  ```ruby
  module CreateUser
    extend Kind::Functional::Action

    def call!(input)
      Step!(:validate, input) \
        >> Step(:create)
    end

    private

    def validate(input)
      # returns Success(valid_data) or Failure(validation)
    end

    def create(input)
      # returns Success(user)
    end
  end
  ```

- Add `kind/strict/disabled` to turn off all of the strict validations and optimize the runtime. Use case: As strict validation is useful in development, this mechanism could be used to optimize the runtime in production. List of methods that will be disabled:
  * `Kind.of()`
  * `Kind.of_class()`
  * `Kind.of_module()`
  * `Kind.of_module_or_class()`
  * `Kind::<Type>[1]`
  * `Kind::NotNil[1]`