### PR TITLE
[5.7.0] Add new strict methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,83 +3,85 @@
 This project follows [semver 2.0.0](http://semver.org/spec/v2.0.0.html) and the recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 - [Unreleased](#unreleased)
-- [5.6.0 (2021-05-14)](#560-2021-05-14)
+- [5.7.0 (2021-06-22)](#570-2021-06-22)
   - [Added](#added)
-- [5.5.0 (2021-04-05)](#550-2021-04-05)
+- [5.6.0 (2021-05-14)](#560-2021-05-14)
   - [Added](#added-1)
+- [5.5.0 (2021-04-05)](#550-2021-04-05)
+  - [Added](#added-2)
 - [5.4.1 (2021-03-26)](#541-2021-03-26)
   - [Fixed](#fixed)
 - [5.4.0 (2021-03-25)](#540-2021-03-25)
-  - [Added](#added-2)
-- [5.3.0 (2021-03-23)](#530-2021-03-23)
   - [Added](#added-3)
-- [5.2.0 (2021-03-17)](#520-2021-03-17)
+- [5.3.0 (2021-03-23)](#530-2021-03-23)
   - [Added](#added-4)
+- [5.2.0 (2021-03-17)](#520-2021-03-17)
+  - [Added](#added-5)
   - [Deprecated](#deprecated)
   - [Changes](#changes)
 - [5.1.0 (2021-02-23)](#510-2021-02-23)
-  - [Added](#added-5)
+  - [Added](#added-6)
   - [Deprecated](#deprecated-1)
 - [5.0.0 (2021-02-22)](#500-2021-02-22)
   - [Breaking Changes](#breaking-changes)
   - [Removed](#removed)
 - [4.1.0 (2021-02-22)](#410-2021-02-22)
-  - [Added](#added-6)
-- [4.0.0 (2021-02-22)](#400-2021-02-22)
   - [Added](#added-7)
+- [4.0.0 (2021-02-22)](#400-2021-02-22)
+  - [Added](#added-8)
   - [Deprecated](#deprecated-2)
   - [Fixed](#fixed-1)
 - [3.1.0 (2020-07-08)](#310-2020-07-08)
-  - [Added](#added-8)
+  - [Added](#added-9)
 - [3.0.0 (2020-06-25)](#300-2020-06-25)
   - [Breaking Changes](#breaking-changes-1)
-  - [Added](#added-9)
-- [2.3.0 (2020-06-24)](#230-2020-06-24)
   - [Added](#added-10)
-- [2.2.0 (2020-06-23)](#220-2020-06-23)
+- [2.3.0 (2020-06-24)](#230-2020-06-24)
   - [Added](#added-11)
-- [2.1.0 (2020-05-12)](#210-2020-05-12)
+- [2.2.0 (2020-06-23)](#220-2020-06-23)
   - [Added](#added-12)
+- [2.1.0 (2020-05-12)](#210-2020-05-12)
+  - [Added](#added-13)
   - [Breaking Changes](#breaking-changes-2)
 - [2.0.0 (2020-05-07)](#200-2020-05-07)
-  - [Added](#added-13)
+  - [Added](#added-14)
   - [Breaking Changes](#breaking-changes-3)
   - [Removed](#removed-1)
 - [1.9.0 (2020-05-06)](#190-2020-05-06)
-  - [Added](#added-14)
-- [1.8.0 (2020-05-03)](#180-2020-05-03)
   - [Added](#added-15)
+- [1.8.0 (2020-05-03)](#180-2020-05-03)
+  - [Added](#added-16)
 - [1.7.0 (2020-05-03)](#170-2020-05-03)
   - [Fixed](#fixed-2)
 - [1.6.0 (2020-04-17)](#160-2020-04-17)
-  - [Added](#added-16)
+  - [Added](#added-17)
   - [Changes](#changes-1)
 - [1.5.0 (2020-04-12)](#150-2020-04-12)
-  - [Added](#added-17)
-- [1.4.0 (2020-04-12)](#140-2020-04-12)
   - [Added](#added-18)
-- [1.3.0 (2020-04-12)](#130-2020-04-12)
+- [1.4.0 (2020-04-12)](#140-2020-04-12)
   - [Added](#added-19)
-- [1.2.0 (2020-04-12)](#120-2020-04-12)
+- [1.3.0 (2020-04-12)](#130-2020-04-12)
   - [Added](#added-20)
-- [1.1.0 (2020-04-09)](#110-2020-04-09)
+- [1.2.0 (2020-04-12)](#120-2020-04-12)
   - [Added](#added-21)
+- [1.1.0 (2020-04-09)](#110-2020-04-09)
+  - [Added](#added-22)
   - [Fixed](#fixed-3)
 - [1.0.0 (2020-03-16)](#100-2020-03-16)
-  - [Added](#added-22)
-- [0.6.0 (2020-01-06)](#060-2020-01-06)
   - [Added](#added-23)
-- [0.5.0 (2020-01-04)](#050-2020-01-04)
+- [0.6.0 (2020-01-06)](#060-2020-01-06)
   - [Added](#added-24)
-- [0.4.0 (2020-01-03)](#040-2020-01-03)
+- [0.5.0 (2020-01-04)](#050-2020-01-04)
   - [Added](#added-25)
-- [0.3.0 (2020-01-03)](#030-2020-01-03)
+- [0.4.0 (2020-01-03)](#040-2020-01-03)
   - [Added](#added-26)
+- [0.3.0 (2020-01-03)](#030-2020-01-03)
+  - [Added](#added-27)
   - [Breaking Changes](#breaking-changes-4)
 - [0.2.0 (2020-01-02)](#020-2020-01-02)
-  - [Added](#added-27)
-- [0.1.0 (2019-12-26)](#010-2019-12-26)
   - [Added](#added-28)
+- [0.1.0 (2019-12-26)](#010-2019-12-26)
+  - [Added](#added-29)
 
 ## Unreleased
 
@@ -90,6 +92,59 @@ This project follows [semver 2.0.0](http://semver.org/spec/v2.0.0.html) and the 
 ### Removed
 ### Fixed
 -->
+
+5.7.0 (2021-06-22)
+------------------
+
+### Added
+
+* [#58](https://github.com/serradura/kind/pull/58) - Add `Add Kind.assert_hash!(hash, keys:)`, you can use the `require_all:` option to check if the hashes have the same keys.
+  ```ruby
+  h1 = {a: 1, b: 1}
+
+  Kind.assert_hash!(h1, keys: [:a, :b])
+  Kind.assert_hash!(h1, keys: [:a]) # ArgumentError (Unknown key: :b. Valid keys are: :a)
+
+  # --
+
+  h2 = {'a' => 1, 'b' => 2}
+
+  Kind.assert_hash!(h2, keys: ['a', 'b'])
+  ```
+
+* [#58](https://github.com/serradura/kind/pull/58) - Add `Add Kind.assert_hash!(hash, schema:)`, you can use the `require_all:` option to check if the hashes have the same keys.
+  ```ruby
+  hash = {hash: {}, array: [], number: 1, string: 'foo', email: 'bar@bar.com', null: nil}
+
+  Kind.assert_hash!(hash, schema: {
+    hash: {},
+    array: [],
+    email: 'bar@bar.com',
+    string: 'foo',
+    number: 1,
+    null: nil
+  })
+
+  Kind.assert_hash!(hash, schema: {
+    hash: Enumerable,
+    array: Enumerable,
+    email: /\A.+@.+\..+\z/,
+    string: String
+  })
+
+  Kind.assert_hash!(hash, schema: {
+    hash: Hash,
+    array: Array,
+    email: String,
+    string: String
+  })
+
+  Kind.assert_hash!(h1, schema: {
+    email: ->(value) { value.is_a?(String) && value.include?('@') }
+  })
+  ```
+
+[⬆️ &nbsp;Back to Top](#changelog-)
 
 5.6.0 (2021-05-14)
 ------------------

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ So, I invite you to check out these features to see how they could be useful for
 Version    | Documentation
 ---------- | -------------
 unreleased | https://github.com/serradura/kind/blob/main/README.md
-5.6.0      | https://github.com/serradura/kind/blob/v5.x/README.md
+5.7.0      | https://github.com/serradura/kind/blob/v5.x/README.md
 4.1.0      | https://github.com/serradura/kind/blob/v4.x/README.md
 3.1.0      | https://github.com/serradura/kind/blob/v3.x/README.md
 2.3.0      | https://github.com/serradura/kind/blob/v2.x/README.md
@@ -125,7 +125,7 @@ unreleased | https://github.com/serradura/kind/blob/main/README.md
 | kind           | branch  | ruby               | activemodel    |
 | -------------- | ------- | ------------------ | -------------- |
 | unreleased     | main    | >= 2.1.0, <= 3.0.0 | >= 3.2, < 7.0  |
-| 5.6.0          | v5.x    | >= 2.1.0, <= 3.0.0 | >= 3.2, < 7.0  |
+| 5.7.0          | v5.x    | >= 2.1.0, <= 3.0.0 | >= 3.2, < 7.0  |
 | 4.1.0          | v4.x    | >= 2.2.0, <= 3.0.0 | >= 3.2, < 7.0  |
 | 3.1.0          | v3.x    | >= 2.2.0, <= 2.7   | >= 3.2, < 7.0  |
 | 2.3.0          | v2.x    | >= 2.2.0, <= 2.7   | >= 3.2, <= 6.0 |

--- a/lib/kind/__lib__/assert_hash_schema.rb
+++ b/lib/kind/__lib__/assert_hash_schema.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module Kind
+  module ASSERT_HASH_KEYS
+    def self.require_all(keys, hash)
+      expected_keys = keys - hash.keys
+
+      unless expected_keys.empty?
+        raise KeyError.new("#{hash.inspect} expected to have these keys: #{expected_keys}")
+      end
+
+      unexpected_keys = hash.keys - keys
+
+      unless unexpected_keys.empty?
+        raise KeyError.new("#{hash.inspect} expected to NOT have these keys: #{unexpected_keys}")
+      end
+
+      hash
+    end
+  end
+
+  module ASSERT_HASH_SCHEMA
+    extend self
+
+    UnionType = ->(value) do
+      defined?(Kind::UnionType) ? Kind::UnionType === value : false
+    end
+
+    def any(hash, spec)
+      spec.each do |key, expected|
+        value = hash[key]
+        error_message = "The key #{key.inspect} has an invalid value"
+
+        case expected
+        when ::Module then assert_kind_of(expected, value, error_message)
+        when ::Proc then assert(expected.call(value), error_message)
+        when ::Regexp then assert_match(expected, value, error_message)
+        when ::NilClass then assert_nil(value, error_message)
+        when UnionType then assert(expected === value, error_message)
+        else assert_equal(expected, value, error_message)
+        end
+      end
+
+      hash
+    end
+
+    def all(hash, spec)
+      ASSERT_HASH_KEYS.require_all(spec.keys, hash)
+
+      any(hash, spec)
+    end
+
+    private
+
+      def assert_equal(expected, value, message)
+        raise_kind_error(message) if expected != value
+      end
+
+      def assert(value, message)
+        raise_kind_error(message) unless value
+      end
+
+      def assert_nil(value, message)
+        raise_kind_error(message) unless value.nil?
+      end
+
+      def assert_match(expected, value, message)
+        STRICT.kind_of(String, value)
+
+        raise_kind_error(message) if value !~ expected
+      end
+
+      def assert_kind_of(expected, value, message)
+        raise_kind_error(message) unless expected === value
+      end
+
+      def raise_kind_error(message)
+        raise Error.new(message)
+      end
+  end
+end

--- a/lib/kind/__lib__/strict.rb
+++ b/lib/kind/__lib__/strict.rb
@@ -49,6 +49,24 @@ module Kind
 
       raise Error.new("#{value} expected to be included in #{list.inspect}")
     end
+
+    def assert_hash!(hash, options)
+      return assert_hash_keys!(hash, options[:keys]) if options.key?(:keys)
+
+      raise ArgumentError, ':keys is missing'
+    end
+
+    private
+
+      def assert_hash_keys!(hash, arg)
+        keys = Array(arg)
+
+        hash.each_key do |k|
+          unless keys.include?(k)
+            raise ArgumentError.new("Unknown key: #{k.inspect}. Valid keys are: #{keys.map(&:inspect).join(', ')}")
+          end
+        end
+      end
   end
 
   private_constant :STRICT

--- a/lib/kind/__lib__/strict.rb
+++ b/lib/kind/__lib__/strict.rb
@@ -43,6 +43,12 @@ module Kind
 
       raise Error.new("#{label_text}expected to not be nil")
     end
+
+    def in!(list, value)
+      return value if list.include?(value)
+
+      raise Error.new("#{value} expected to be included in #{list.inspect}")
+    end
   end
 
   private_constant :STRICT

--- a/lib/kind/basic.rb
+++ b/lib/kind/basic.rb
@@ -2,8 +2,8 @@
 
 require 'kind/version'
 
-require 'kind/__lib__/kind'
 require 'kind/__lib__/undefined'
+require 'kind/__lib__/kind'
 
 require 'kind/basic/undefined'
 require 'kind/basic/error'
@@ -79,5 +79,17 @@ module Kind
 
   def or_nil(kind, value)
     return value if kind === value
+  end
+
+  def in!(list, value)
+    STRICT.in!(list, value)
+  end
+
+  def include!(value, list)
+    STRICT.in!(list, value)
+  end
+
+  def include!(value, list)
+    STRICT.in!(list, value)
   end
 end

--- a/lib/kind/basic.rb
+++ b/lib/kind/basic.rb
@@ -89,7 +89,7 @@ module Kind
     STRICT.in!(list, value)
   end
 
-  def include!(value, list)
-    STRICT.in!(list, value)
+  def assert_hash!(hash, **kargs)
+    STRICT.assert_hash!(hash, kargs)
   end
 end

--- a/lib/kind/strict/disabled.rb
+++ b/lib/kind/strict/disabled.rb
@@ -3,8 +3,14 @@
 module Kind
   module STRICT
     [
-      :object_is_a, :class!, :kind_of,
-      :module_or_class, :module!, :not_nil
+      :object_is_a,
+      :class!,
+      :kind_of,
+      :module_or_class,
+      :module!,
+      :not_nil,
+      :in!,
+      :assert_hash!
     ].each { |method_name| remove_method(method_name) }
 
     def object_is_a(_kind, value, _label = nil) # :nodoc:
@@ -29,6 +35,14 @@ module Kind
 
     def not_nil(value, label) # :nodoc:
       value
+    end
+
+    def in!(list, value) # :nodoc:
+      value
+    end
+
+    def assert_hash!(hash, _options) # :nodoc:
+      hash
     end
   end
 end

--- a/lib/kind/strict/disabled.rb
+++ b/lib/kind/strict/disabled.rb
@@ -44,5 +44,9 @@ module Kind
     def assert_hash!(hash, _options) # :nodoc:
       hash
     end
+
+    def assert_hash!(hash, _options) # :nodoc:
+      hash
+    end
   end
 end

--- a/lib/kind/version.rb
+++ b/lib/kind/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Kind
-  VERSION = '5.6.0'
+  VERSION = '5.7.0'
 end

--- a/test/kind/basic_test.rb
+++ b/test/kind/basic_test.rb
@@ -256,4 +256,56 @@ class Kind::KindTest < Minitest::Test
       '1 expected to be included in ["a", :b]'
     ) { Kind.include!(1, ['a', :b]) }
   end
+
+  def test_Kind_assert_hash!
+    assert_raises_with_message(
+      ArgumentError,
+      ':keys is missing'
+    ) { Kind.assert_hash!({}, some: :arg) }
+  end
+
+  def test_Kind_assert_hash_keys
+    h1 = {a: 1, b: 1}
+    h2 = {'a' => 1, 'b' => 2}
+
+    # --
+
+    assert_equal(h1, Kind.assert_hash!(h1, keys: [:a, :b]))
+    assert_equal(h1, Kind.assert_hash!(h1, keys: [:a, :b, :c]))
+
+    assert_raises_with_message(
+      ArgumentError,
+      'Unknown key: :b. Valid keys are: :a'
+    ) { Kind.assert_hash!(h1, keys: [:a]) }
+
+    assert_raises_with_message(
+      ArgumentError,
+      'Unknown key: :a. Valid keys are: :b'
+    ) { Kind.assert_hash!(h1, keys: :b) }
+
+    assert_raises_with_message(
+      ArgumentError,
+      'Unknown key: "a". Valid keys are: :a, :b'
+    ) { Kind.assert_hash!(h2, keys: [:a, :b]) }
+
+    # --
+
+    assert_equal(h2, Kind.assert_hash!(h2, keys: ['a', 'b']))
+    assert_equal(h2, Kind.assert_hash!(h2, keys: ['a', 'b', 'c']))
+
+    assert_raises_with_message(
+      ArgumentError,
+      'Unknown key: "a". Valid keys are: "b"'
+    ) { Kind.assert_hash!(h2, keys: ['b']) }
+
+    assert_raises_with_message(
+      ArgumentError,
+      'Unknown key: "b". Valid keys are: "a"'
+    ) { Kind.assert_hash!(h2, keys: 'a') }
+
+    assert_raises_with_message(
+      ArgumentError,
+      'Unknown key: :a. Valid keys are: "a", "b"'
+    ) { Kind.assert_hash!(h1, keys: ['a', 'b']) }
+  end
 end

--- a/test/kind/basic_test.rb
+++ b/test/kind/basic_test.rb
@@ -232,4 +232,28 @@ class Kind::KindTest < Minitest::Test
 
     assert_equal('1', Kind.or_nil(filled_string, '1'))
   end
+
+  def test_Kind_in!
+    assert 'a' == Kind.in!(['a', :b], 'a')
+
+    assert :b == Kind.in!(['a', :b], :b)
+
+    # FACT: The default value must be of the expected kind.
+    assert_raises_with_message(
+      Kind::Error,
+      '1 expected to be included in ["a", :b]'
+    ) { Kind.in!(['a', :b], 1) }
+  end
+
+  def test_Kind_include!
+    assert 'a' == Kind.include!('a', ['a', :b])
+
+    assert :b == Kind.include!(:b, ['a', :b])
+
+    # FACT: The default value must be of the expected kind.
+    assert_raises_with_message(
+      Kind::Error,
+      '1 expected to be included in ["a", :b]'
+    ) { Kind.include!(1, ['a', :b]) }
+  end
 end

--- a/test/kind/basic_test.rb
+++ b/test/kind/basic_test.rb
@@ -260,11 +260,11 @@ class Kind::KindTest < Minitest::Test
   def test_Kind_assert_hash!
     assert_raises_with_message(
       ArgumentError,
-      ':keys is missing'
+      ':keys or :schema is missing'
     ) { Kind.assert_hash!({}, some: :arg) }
   end
 
-  def test_Kind_assert_hash_keys
+  def test_Kind_assert_hash_keys___require_all_false
     h1 = {a: 1, b: 1}
     h2 = {'a' => 1, 'b' => 2}
 
@@ -307,5 +307,135 @@ class Kind::KindTest < Minitest::Test
       ArgumentError,
       'Unknown key: :a. Valid keys are: "a", "b"'
     ) { Kind.assert_hash!(h1, keys: ['a', 'b']) }
+  end
+
+  def test_Kind_assert_hash_keys___require_all_true
+    h1 = {a: 1, b: 1}
+    h2 = {'a' => 1, 'b' => 2}
+
+    # --
+
+    assert_equal(h1, Kind.assert_hash!(h1, keys: [:a, :b], require_all: true))
+
+    assert_raises_with_message(
+      KeyError,
+      '{:a=>1, :b=>1} expected to have these keys: [:c]'
+    ) { Kind.assert_hash!(h1, keys: [:a, :b, :c], require_all: true) }
+
+    assert_raises_with_message(
+      KeyError,
+      '{:a=>1, :b=>1} expected to NOT have these keys: [:b]'
+    ) { Kind.assert_hash!(h1, keys: [:a], require_all: true) }
+
+    assert_raises_with_message(
+      KeyError,
+      '{:a=>1, :b=>1} expected to NOT have these keys: [:a]'
+    ) { Kind.assert_hash!(h1, keys: :b, require_all: true) }
+
+    assert_raises_with_message(
+      KeyError,
+      '{"a"=>1, "b"=>2} expected to have these keys: [:a, :b]'
+    ) { Kind.assert_hash!(h2, keys: [:a, :b], require_all: true) }
+
+    # --
+
+    assert_equal(h2, Kind.assert_hash!(h2, keys: ['a', 'b'], require_all: true))
+
+    assert_raises_with_message(
+      KeyError,
+      '{"a"=>1, "b"=>2} expected to have these keys: ["c"]'
+    ) { Kind.assert_hash!(h2, keys: ['a', 'b', 'c'], require_all: true) }
+
+    assert_raises_with_message(
+      KeyError,
+      '{"a"=>1, "b"=>2} expected to NOT have these keys: ["a"]'
+    ) { Kind.assert_hash!(h2, keys: ['b'], require_all: true) }
+
+    assert_raises_with_message(
+      KeyError,
+      '{"a"=>1, "b"=>2} expected to NOT have these keys: ["b"]'
+    ) { Kind.assert_hash!(h2, keys: 'a', require_all: true) }
+
+    assert_raises_with_message(
+      KeyError,
+      '{:a=>1, :b=>1} expected to have these keys: ["a", "b"]'
+    ) { Kind.assert_hash!(h1, keys: ['a', 'b'], require_all: true) }
+  end
+
+  def test_Kind_assert_schema___require_all_false
+    h1 = {hash: {}, array: [], number: 1, string: 'foo', email: 'bar@bar.com', null: nil}
+
+    # --
+
+    assert_equal(h1, Kind.assert_hash!(h1, schema: {
+      hash: {},
+      array: [],
+      email: 'bar@bar.com',
+      string: 'foo',
+      number: 1,
+      null: nil
+    }))
+
+    assert_equal(h1, Kind.assert_hash!(h1, schema: {
+      hash: Enumerable,
+      array: Enumerable,
+      email: /\A.+@.+\..+\z/,
+      string: String
+    }))
+
+    assert_equal(h1, Kind.assert_hash!(h1, schema: {
+      hash: Hash,
+      array: Array,
+      email: String,
+      string: String
+    }))
+
+    assert_equal(h1, Kind.assert_hash!(h1, schema: {
+      email: ->(value) { value.is_a?(String) && value.include?('@') }
+    }))
+
+    # # --
+
+    assert_raises_with_message(
+      Kind::Error,
+      'The key :email has an invalid value'
+    ) do
+      Kind.assert_hash!(h1, schema: {email: ->(value) { !value.is_a?(String) }})
+    end
+
+    assert_raises_with_message(
+      Kind::Error,
+      'The key :email has an invalid value'
+    ) { Kind.assert_hash!(h1, schema: {email: /\s.*\s/ }) }
+
+    assert_raises_with_message(
+      Kind::Error,
+      'The key :email has an invalid value'
+    ) { Kind.assert_hash!(h1, schema: {email: Numeric}) }
+
+    assert_raises_with_message(
+      Kind::Error,
+      'The key :email has an invalid value'
+    ) { Kind.assert_hash!(h1, schema: {email: 'foo@foo.com'}) }
+
+    assert_raises_with_message(
+      Kind::Error,
+      'The key :email has an invalid value'
+    ) { Kind.assert_hash!(h1, schema: {email: nil}) }
+  end
+
+  def test_Kind_assert_schema___require_all_true
+    h1 = {email: '', number: 1}
+
+    # --
+
+    assert_raises_with_message(
+      KeyError,
+      '{:email=>"", :number=>1} expected to NOT have these keys: [:number]'
+    ) { Kind.assert_hash!(h1, require_all: true, schema: {email: String}) }
+
+    # --
+
+    assert_equal(h1, Kind.assert_hash!(h1, require_all: true, schema: {email: String, number: Numeric}))
   end
 end

--- a/test/kind/maybe_test.rb
+++ b/test/kind/maybe_test.rb
@@ -467,7 +467,7 @@ class Kind::MaybeTest < Minitest::Test
     # --
 
     exception_message =
-      RUBY_VERSION < '2.2.0' ? 'wrong number of arguments (1 for 0)' : 'wrong number of arguments (given 1, expected 0)'
+      RUBY_VERSION < '2.3.0' ? 'wrong number of arguments (1 for 0)' : 'wrong number of arguments (given 1, expected 0)'
 
     assert_raises_with_message(ArgumentError, exception_message) { Kind::None(nil) }
   end
@@ -487,7 +487,7 @@ class Kind::MaybeTest < Minitest::Test
     # --
 
     exception_message =
-      RUBY_VERSION < '2.2.0' ? 'wrong number of arguments (0 for 1)' : 'wrong number of arguments (given 0, expected 1)'
+      RUBY_VERSION < '2.3.0' ? 'wrong number of arguments (0 for 1)' : 'wrong number of arguments (given 0, expected 1)'
 
     assert_raises_with_message(ArgumentError, exception_message) { Kind::Some() }
 
@@ -620,7 +620,7 @@ class Kind::MaybeTest < Minitest::Test
     ) { Kind::Maybe.from }
 
     exception_message =
-      RUBY_VERSION < '2.2.0' ? 'wrong number of arguments (1 for 0)' : 'wrong number of arguments (given 1, expected 0)'
+      RUBY_VERSION < '2.3.0' ? 'wrong number of arguments (1 for 0)' : 'wrong number of arguments (given 1, expected 0)'
 
     assert_raises_with_message(
       ArgumentError,

--- a/test/kind/objects/union_type_test.rb
+++ b/test/kind/objects/union_type_test.rb
@@ -22,4 +22,17 @@ class Kind::UnionTypeTest < Minitest::Test
       ) { union_type[1] }
     end
   end
+
+  def test_assert_hash_schema
+    h1 = {hash: {}, array: []}
+
+    # --
+
+    hash_or_array = Kind::Array | Hash
+
+    assert_equal(h1, Kind.assert_hash!(h1, schema: {
+      hash: hash_or_array,
+      array: hash_or_array
+    }))
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,7 +18,7 @@ ENV.fetch('ACTIVEMODEL_VERSION', '7.0.0').tap do |active_model_version|
     require 'kind/active_model/validation'
   end
 
-  if (RUBY_VERSION < '2.2.0' || active_model_version < '4.1')
+  if (RUBY_VERSION < '2.3.0' || active_model_version < '4.1')
     require 'minitest/unit'
 
     module Minitest


### PR DESCRIPTION
* Add `Add Kind.assert_hash!(hash, keys:)`, you can use the `require_all:` option to check if the hashes have the same keys.
  ```ruby
  h1 = {a: 1, b: 1}

  Kind.assert_hash!(h1, keys: [:a, :b])
  Kind.assert_hash!(h1, keys: [:a]) # ArgumentError (Unknown key: :b. Valid keys are: :a)

  # --

  h2 = {'a' => 1, 'b' => 2}

  Kind.assert_hash!(h2, keys: ['a', 'b'])
  ```

* Add `Add Kind.assert_hash!(hash, schema:)`, you can use the `require_all:` option to check if the hashes have the same keys.
  ```ruby
  hash = {hash: {}, array: [], number: 1, string: 'foo', email: 'bar@bar.com', null: nil}

  Kind.assert_hash!(hash, schema: {
    hash: {},
    array: [],
    email: 'bar@bar.com',
    string: 'foo',
    number: 1,
    null: nil
  })

  Kind.assert_hash!(hash, schema: {
    hash: Enumerable,
    array: Enumerable,
    email: /\A.+@.+\..+\z/,
    string: String
  })

  Kind.assert_hash!(hash, schema: {
    hash: Hash,
    array: Array,
    email: String,
    string: String
  })

  Kind.assert_hash!(h1, schema: {
    email: ->(value) { value.is_a?(String) && value.include?('@') }
  })
  ```