### PR TITLE
Add Kind::ID

### DIFF
--- a/lib/kind/objects/modules.rb
+++ b/lib/kind/objects/modules.rb
@@ -29,4 +29,5 @@ require 'kind/objects/modules/stdlib/set'
 
 require 'kind/objects/modules/custom/boolean'
 require 'kind/objects/modules/custom/callable'
+require 'kind/objects/modules/custom/id'
 require 'kind/objects/modules/custom/lambda'

--- a/lib/kind/objects/modules/custom/id.rb
+++ b/lib/kind/objects/modules/custom/id.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Kind
+  module ID
+    extend self, ::Kind::Object
+
+    def kind; [::Integer, ::String]; end
+
+    def name; 'ID'; end
+
+    def ===(value)
+      value.kind_of?(::Integer) && value.positive? ||
+        value.kind_of?(::String) && value =~ /^\d+$/ && value.to_i.positive? ||
+        value.kind_of?(::String) && /\A[\da-f]{32}\z/i.match?(value) ||
+        value.kind_of?(::String) && /\A(urn:uuid:)?[\da-f]{8}-([\da-f]{4}-){3}[\da-f]{12}\z/i.match?(value)
+    end
+  end
+
+  def self.ID?(*values)
+    KIND.of?(ID, values)
+  end
+end

--- a/test/kind/objects/modules_test.rb
+++ b/test/kind/objects/modules_test.rb
@@ -310,6 +310,24 @@ class Kind::ModulesTest < Minitest::Test
     assert Kind::Callable?(-> {}, ''.method(:upcase))
     refute Kind::Callable?(-> {}, 1)
 
+    # == Kind::ID ==
+
+    assert Kind.of_module?(Kind::ID)
+    assert Kind.is?(Kind::Object, Kind::ID)
+    assert Kind::ID.kind == [Integer, String]
+    assert Kind::ID.name == 'ID'
+    assert Kind::ID?(12345)
+    assert Kind::ID?('12345')
+    assert Kind::ID?('e4379200-061c-11ec-9a03-0242ac130003')
+    assert Kind::ID?('7dfea486-bd6e-423a-80ab-003dfec23933')
+    refute Kind::ID?(0)
+    refute Kind::ID?('0')
+    refute Kind::ID?('12345t')
+    refute Kind::ID?('123t45')
+    refute Kind::ID?('t12345')
+    refute Kind::ID?('e4379200-061c-11ec-9a03-0242ac13000')
+    refute Kind::ID?('7dfea486-bd6e-423a-80ab-003dfec2393')
+
     # == Kind::Lambda ==
 
     assert Kind.of_module?(Kind::Lambda)


### PR DESCRIPTION
## Summary

This PR adds a _custom_ **Kind::ID** type that can represent IDs and UUIDs.

It's used the Ruby _Integer_ and _String_ classes as its "kind".

- IDs are validated checking if the given value is positive;
- UUIDs are validated using regular expressions for the given value.

## Testing

The following cases were tested:

```ruby

Kind::ID[12345]  # 12345

Kind::ID['12345']  # "12345"

Kind::ID[0]  # Kind::Error: 0 expected to be a kind of ID

Kind::ID['0']  # Kind::Error: "0" expected to be a kind of ID

Kind::ID['12345t']  # Kind::Error: "12345t" expected to be a kind of ID

Kind::ID['t12345']  # Kind::Error: "t12345" expected to be a kind of ID

Kind::ID['123t45']  # Kind::Error: "123t45" expected to be a kind of ID

```

```ruby

Kind::ID['e4379200-061c-11ec-9a03-0242ac130003']  # "e4379200-061c-11ec-9a03-0242ac130003"

Kind::ID['e4379200-061c-11ec-9a03-0242ac13000']  # Kind::Error: "e4379200-061c-11ec-9a03-0242ac13000" expected to be a kind of ID

Kind::ID['7dfea486-bd6e-423a-80ab-003dfec23933']  # "7dfea486-bd6e-423a-80ab-003dfec23933"

Kind::ID['7dfea486-bd6e-423a-80ab-003dfec23933']  # Kind::Error: "7dfea486-bd6e-423a-80ab-003dfec23933" expected to be a kind of ID

```