### PR TITLE
[5.8.1] Make Kind.assert_hash!(_, schema:) works with a Kind::Any

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 This project follows [semver 2.0.0](http://semver.org/spec/v2.0.0.html) and the recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 - [Unreleased](#unreleased)
+- [5.8.1 (2021-09-22)](#581-2021-09-22)
+  - [Fixed](#fixed)
 - [5.8.0 (2021-09-22)](#580-2021-09-22)
   - [Added](#added)
 - [5.7.0 (2021-06-22)](#570-2021-06-22)
@@ -12,7 +14,7 @@ This project follows [semver 2.0.0](http://semver.org/spec/v2.0.0.html) and the 
 - [5.5.0 (2021-04-05)](#550-2021-04-05)
   - [Added](#added-3)
 - [5.4.1 (2021-03-26)](#541-2021-03-26)
-  - [Fixed](#fixed)
+  - [Fixed](#fixed-1)
 - [5.4.0 (2021-03-25)](#540-2021-03-25)
   - [Added](#added-4)
 - [5.3.0 (2021-03-23)](#530-2021-03-23)
@@ -32,7 +34,7 @@ This project follows [semver 2.0.0](http://semver.org/spec/v2.0.0.html) and the 
 - [4.0.0 (2021-02-22)](#400-2021-02-22)
   - [Added](#added-9)
   - [Deprecated](#deprecated-2)
-  - [Fixed](#fixed-1)
+  - [Fixed](#fixed-2)
 - [3.1.0 (2020-07-08)](#310-2020-07-08)
   - [Added](#added-10)
 - [3.0.0 (2020-06-25)](#300-2020-06-25)
@@ -54,7 +56,7 @@ This project follows [semver 2.0.0](http://semver.org/spec/v2.0.0.html) and the 
 - [1.8.0 (2020-05-03)](#180-2020-05-03)
   - [Added](#added-17)
 - [1.7.0 (2020-05-03)](#170-2020-05-03)
-  - [Fixed](#fixed-2)
+  - [Fixed](#fixed-3)
 - [1.6.0 (2020-04-17)](#160-2020-04-17)
   - [Added](#added-18)
   - [Changes](#changes-1)
@@ -68,7 +70,7 @@ This project follows [semver 2.0.0](http://semver.org/spec/v2.0.0.html) and the 
   - [Added](#added-22)
 - [1.1.0 (2020-04-09)](#110-2020-04-09)
   - [Added](#added-23)
-  - [Fixed](#fixed-3)
+  - [Fixed](#fixed-4)
 - [1.0.0 (2020-03-16)](#100-2020-03-16)
   - [Added](#added-24)
 - [0.6.0 (2020-01-06)](#060-2020-01-06)
@@ -94,6 +96,23 @@ This project follows [semver 2.0.0](http://semver.org/spec/v2.0.0.html) and the 
 ### Removed
 ### Fixed
 -->
+
+5.8.1 (2021-09-22)
+------------------
+
+### Fixed
+
+* [#67](https://github.com/serradura/kind/pull/67) - Make `Kind.assert_hash!(some_hash, schema:)` works with a `Kind::Any` instance.
+```ruby
+require 'kind/any'
+
+Level = Kind::Any[:low, :high]
+
+Kind.assert_hash!({level: :medium}, schema: {level: Level})
+# Kind::Error (The key :status has an invalid value. Expected: Kind::Any[:low, :high])
+```
+
+[⬆️ &nbsp;Back to Top](#changelog-)
 
 5.8.0 (2021-09-22)
 ------------------

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ So, I invite you to check out these features to see how they could be useful for
 Version    | Documentation
 ---------- | -------------
 unreleased | https://github.com/serradura/kind/blob/main/README.md
-5.8.0      | https://github.com/serradura/kind/blob/v5.x/README.md
+5.8.1      | https://github.com/serradura/kind/blob/v5.x/README.md
 4.1.0      | https://github.com/serradura/kind/blob/v4.x/README.md
 3.1.0      | https://github.com/serradura/kind/blob/v3.x/README.md
 2.3.0      | https://github.com/serradura/kind/blob/v2.x/README.md
@@ -125,7 +125,7 @@ unreleased | https://github.com/serradura/kind/blob/main/README.md
 | kind           | branch  | ruby               | activemodel    |
 | -------------- | ------- | ------------------ | -------------- |
 | unreleased     | main    | >= 2.1.0, <= 3.0.0 | >= 3.2, < 7.0  |
-| 5.8.0          | v5.x    | >= 2.1.0, <= 3.0.0 | >= 3.2, < 7.0  |
+| 5.8.1          | v5.x    | >= 2.1.0, <= 3.0.0 | >= 3.2, < 7.0  |
 | 4.1.0          | v4.x    | >= 2.2.0, <= 3.0.0 | >= 3.2, < 7.0  |
 | 3.1.0          | v3.x    | >= 2.2.0, <= 2.7   | >= 3.2, < 7.0  |
 | 2.3.0          | v2.x    | >= 2.2.0, <= 2.7   | >= 3.2, <= 6.0 |

--- a/lib/kind/__lib__/assert_hash.rb
+++ b/lib/kind/__lib__/assert_hash.rb
@@ -23,13 +23,9 @@ module Kind
     module Schema
       extend self
 
-      KindObject = ->(value) do
-        defined?(Kind::Object) ? Kind::Object === value : false
-      end
-
-      KindUnionType = ->(value) do
-        defined?(Kind::UnionType) ? Kind::UnionType === value : false
-      end
+      KindAny = ->(value) { defined?(Kind::Any) ? Kind::Any === value : false }
+      KindObject = ->(value) { defined?(Kind::Object) ? Kind::Object === value : false }
+      KindUnionType = ->(value) { defined?(Kind::UnionType) ? Kind::UnionType === value : false }
 
       def any(hash, spec)
         spec.each do |key, expected|
@@ -37,7 +33,7 @@ module Kind
           error_message = "The key #{key.inspect} has an invalid value"
 
           case expected
-          when KindUnionType, KindObject then assert_kind_object(expected, value, error_message)
+          when KindAny, KindObject, KindUnionType then assert_kind_object(expected, value, error_message)
           when ::Module then assert_kind_of(expected, value, error_message)
           when ::Proc then assert(expected.call(value), error_message)
           when ::Regexp then assert_match(expected, value, error_message)
@@ -58,7 +54,7 @@ module Kind
       private
 
         def assert_equal(expected, value, message)
-          raise_kind_error("#{message}. Expected: #{expected}, Given: #{value}") if expected != value
+          raise_kind_error("#{message}. Expected: #{expected.inspect}, Given: #{value.inspect}") if expected != value
         end
 
         def assert(value, message)
@@ -72,11 +68,11 @@ module Kind
         def assert_match(expected, value, message)
           STRICT.kind_of(String, value)
 
-          raise_kind_error("#{message}. Expected: #{expected}") if value !~ expected
+          raise_kind_error("#{message}. Expected: #{expected.inspect}") if value !~ expected
         end
 
         def assert_kind_of(expected, value, message)
-          raise_kind_error("#{message}. Expected: #{expected}") unless expected === value
+          raise_kind_error("#{message}. Expected: #{expected.inspect}") unless expected === value
         end
 
         def assert_kind_object(expected, value, message)

--- a/lib/kind/version.rb
+++ b/lib/kind/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Kind
-  VERSION = '5.8.0'
+  VERSION = '5.8.1'
 end

--- a/test/kind/any_test.rb
+++ b/test/kind/any_test.rb
@@ -70,4 +70,11 @@ class Kind::AnyTest < Minitest::Test
       assert status.values == %w[open close]
     end
   end
+
+  def test_kind_assert_hash
+    assert_raises_with_message(
+      Kind::Error,
+      'The key :status has an invalid value. Expected: Kind::Any["open", "close"]'
+    ) { Kind.assert_hash!({status: 'foo'}, schema: {status: Status1}) }
+  end
 end

--- a/test/kind/basic_test.rb
+++ b/test/kind/basic_test.rb
@@ -415,7 +415,7 @@ class Kind::KindTest < Minitest::Test
 
     assert_raises_with_message(
       Kind::Error,
-      'The key :email has an invalid value. Expected: (?-mix:\\s.*\\s)'
+      'The key :email has an invalid value. Expected: /\\s.*\\s/'
     ) { Kind.assert_hash!(h1, schema: {email: /\s.*\s/ }) }
 
     assert_raises_with_message(
@@ -425,36 +425,13 @@ class Kind::KindTest < Minitest::Test
 
     assert_raises_with_message(
       Kind::Error,
-      'The key :email has an invalid value. Expected: foo@foo.com, Given: bar@bar.com'
+      'The key :email has an invalid value. Expected: "foo@foo.com", Given: "bar@bar.com"'
     ) { Kind.assert_hash!(h1, schema: {email: 'foo@foo.com'}) }
 
     assert_raises_with_message(
       Kind::Error,
       'The key :email has an invalid value. Expected: nil'
     ) { Kind.assert_hash!(h1, schema: {email: nil}) }
-
-    if defined?(Kind::Object) && defined?(Kind::UnionType)
-      assert_raises_with_message(
-        Kind::Error,
-        'The key :number has an invalid value. Expected: (String | Symbol)'
-      ) { Kind.assert_hash!(h1, schema: {number: Kind[String] | Symbol}) }
-
-      assert_raises_with_message(
-        Kind::Error,
-        'The key :number has an invalid value. Expected: String'
-      ) { Kind.assert_hash!(h1, schema: {number: Kind::String}) }
-
-      filled_string = begin
-        filled_str = ->(value) {value.is_a?(String) && !value.empty?}
-
-        Kind::Of(filled_str, name: 'FilledString')
-      end
-
-      assert_raises_with_message(
-        Kind::Error,
-        'The key :string has an invalid value. Expected: FilledString'
-      ) { Kind.assert_hash!({string: ''}, schema: {string: filled_string}) }
-    end
   end
 
   def test_Kind_assert_schema___require_all_true

--- a/test/kind/objects/object_test.rb
+++ b/test/kind/objects/object_test.rb
@@ -139,4 +139,22 @@ class Kind::ObjectTest < Minitest::Test
       'nil expected to be a kind of String'
     ) { Kind::Object::Instance.new([], {}) }
   end
+
+  def test_kind_assert_hash
+    assert_raises_with_message(
+      Kind::Error,
+      'The key :string has an invalid value. Expected: String'
+    ) { Kind.assert_hash!({string: 1}, schema: {string: Kind::String}) }
+
+    filled_string = begin
+      filled_str = ->(value) {value.is_a?(String) && !value.empty?}
+
+      Kind::Of(filled_str, name: 'FilledString')
+    end
+
+    assert_raises_with_message(
+      Kind::Error,
+      'The key :string has an invalid value. Expected: FilledString'
+    ) { Kind.assert_hash!({string: ''}, schema: {string: filled_string}) }
+  end
 end

--- a/test/kind/objects/union_type_test.rb
+++ b/test/kind/objects/union_type_test.rb
@@ -35,4 +35,11 @@ class Kind::UnionTypeTest < Minitest::Test
       array: hash_or_array
     }))
   end
+
+  def test_kind_assert_hash
+    assert_raises_with_message(
+      Kind::Error,
+      'The key :status has an invalid value. Expected: (String | Symbol)'
+    ) { Kind.assert_hash!({status: 0}, schema: {status: Kind[String] | Symbol}) }
+  end
 end


### PR DESCRIPTION
```ruby
require 'kind/any'

Level = Kind::Any[:low, :high]

Kind.assert_hash!({level: :medium}, schema: {level: Level})
# Kind::Error (The key :status has an invalid value. Expected: Kind::Any[:low, :high])
```