### PR TITLE
Add #to_proc to Kind::Maybe

### DIFF
--- a/lib/kind/maybe.rb
+++ b/lib/kind/maybe.rb
@@ -18,6 +18,10 @@ module Kind
         .new(value)
     end
 
+    def to_proc
+      ->(value) { new(value) }
+    end
+
     alias_method :[], :new
 
     module Buildable

--- a/test/kind/maybe_test.rb
+++ b/test/kind/maybe_test.rb
@@ -11,6 +11,14 @@ class Kind::MaybeTest < Minitest::Test
     assert_equal(0, Kind::Maybe.new(optional).value)
   end
 
+  def test_to_proc
+    to_proc_maybe = 0.then(&Kind::Maybe)
+
+    constructor_maybe = Kind::Maybe.new(0)
+
+    assert_equal(constructor_maybe.value, to_proc_maybe.value)
+  end
+
   def test_maybe_result
     object = Object.new
 


### PR DESCRIPTION
Adds another way to create a `Kind::Maybe`:

```ruby
result = operation_that_can_return_nil().then(&Kind::Maybe)
```
